### PR TITLE
Don't allow ip6addresses without double quotes and document it

### DIFF
--- a/unirecfilter/README.md
+++ b/unirecfilter/README.md
@@ -57,7 +57,7 @@ Almost all data types from unirec are supported:
 - `char`  a single ASCII character
 - `float` single precision floating point number (IEEE 754)
 - `double` double precision floating point number (IEEE 754)
-- `ipaddr` special type for IPv4/IPv6 addresses, see unirec README (note -  IPv6 address in a filter loaded from a file has to be surrounded by double quotes because of syntax issues)
+- `ipaddr` special type for IPv4/IPv6 addresses, see unirec README (note -  IPv6 addresses have to be surrounded by double quotes because of syntax issues)
 - `string` variable-length array of (mostly) printable characters, surrounded by double quotes
 - `bytes` variable-length array of bytes (not expected to be printable characters), surrounded by double quotes
 

--- a/unirecfilter/lib/scanner.l
+++ b/unirecfilter/lib/scanner.l
@@ -37,7 +37,7 @@ IPv6    ({h16}:){6}{ls32}|::({h16}:){5}{ls32}|({h16})?::({h16}:){4}{ls32}|(({h16
 -[0-9]+                                                  { sscanf(yytext, "%" SCNi64, &yylval.number); return SIGNED; }
 [0-9]+                                                   { sscanf(yytext, "%" SCNi64, &yylval.number); return UNSIGNED; }
 {IPv4}                                                   { yylval.string = copyString(yytext, yyleng); return IP; }
-\"?{IPv6}\"?                                             { yylval.string = cutString(yytext, yyleng); return IP; }
+\"{IPv6}\"                                               { yylval.string = cutString(yytext, yyleng); return IP; }
 "PROTOCOL"                                               { return PROTOCOL; }
 "TCP"|"ICMP"|"UDP"                                       { yylval.string = copyString(yytext, yyleng); return PROTO_NAME; }
 [a-zA-Z_]+                                               { yylval.string = copyString(yytext, yyleng); return COLUMN; }


### PR DESCRIPTION
Alternatively you could use the version in my branch unirecfilter-ip6-addrs2 which tries to enable both variants, let me know if you'd like a pull request of that instead, i'm not quite sure how to test it.