### PR TITLE
unirecfilter scanner: do not assume double quotes around ip6addrs.

### DIFF
--- a/unirecfilter/lib/scanner.l
+++ b/unirecfilter/lib/scanner.l
@@ -37,7 +37,8 @@ IPv6    ({h16}:){6}{ls32}|::({h16}:){5}{ls32}|({h16})?::({h16}:){4}{ls32}|(({h16
 -[0-9]+                                                  { sscanf(yytext, "%" SCNi64, &yylval.number); return SIGNED; }
 [0-9]+                                                   { sscanf(yytext, "%" SCNi64, &yylval.number); return UNSIGNED; }
 {IPv4}                                                   { yylval.string = copyString(yytext, yyleng); return IP; }
-\"?{IPv6}\"?                                             { yylval.string = cutString(yytext, yyleng); return IP; }
+\"{IPv6}\"                                               { yylval.string = cutString(yytext, yyleng); return IP; }
+{IPv6}                                                   { yylval.string = copyString(yytext, yyleng); return IP; }
 "PROTOCOL"                                               { return PROTOCOL; }
 "TCP"|"ICMP"|"UDP"                                       { yylval.string = copyString(yytext, yyleng); return PROTO_NAME; }
 [a-zA-Z_]+                                               { yylval.string = copyString(yytext, yyleng); return COLUMN; }


### PR DESCRIPTION
Only use action with cutString for addresses given in double quotes, add
new pattern with copyString action for literal addresses.