### PR TITLE
email_reporter: Sort field names from longest to shortest.

### DIFF
--- a/email_reporter/email_reporter.py
+++ b/email_reporter/email_reporter.py
@@ -256,9 +256,8 @@ msg_template = msg_template.replace("%", "%%")
 # to shortest (to solve a problem when there are fields ABC and ABCD and we 
 # should substitute $ABCD)
 fields = [i.split(" ")[1] for i in unirecfmt.split(",")]
-fields.sort()
-#fields.sort(lambda a,b: cmp(len(a),len(b)), reverse=True)
 fields.append('_DATETIME_')
+fields.sort(key=len, reverse=True)
 # Substitute all occurences of '$FIELD_NAME' by '%(FIELD_NAME)s'
 for f in fields:
    msg_template = msg_template.replace("$"+f, "%("+f+")s")


### PR DESCRIPTION
The sort invocation has been tested in Python 2 and 3.