### PR TITLE
Improvement of unirecfilter: ur_time_t fields comparison

### DIFF
--- a/unirecfilter/README.md
+++ b/unirecfilter/README.md
@@ -45,11 +45,11 @@ Available logical operators are:
 
 Almost all data types from unirec are supported:
 
-- `int8` 8bit singed integer
-- `int16` 16bit singed integer
-- `int32` 32bit singed integer
-- `int32` 32bit singed integer
-- `int64` 64bit singed integer
+- `int8` 8bit signed integer
+- `int16` 16bit signed integer
+- `int32` 32bit signed integer
+- `int32` 32bit signed integer
+- `int64` 64bit signed integer
 - `uint8` 8bit unsigned integer
 - `uint16` 16bit unsigned integer
 - `uint32` 32bit unsigned integer

--- a/unirecfilter/README.md
+++ b/unirecfilter/README.md
@@ -60,6 +60,7 @@ Almost all data types from unirec are supported:
 - `ipaddr` special type for IPv4/IPv6 addresses, see unirec README (note -  IPv6 address in a filter loaded from a file has to be surrounded by double quotes because of syntax issues)
 - `string` variable-length array of (mostly) printable characters, surrounded by double quotes
 - `bytes` variable-length array of bytes (not expected to be printable characters), surrounded by double quotes
+- `time` UniRec timestamp, such as `TIME_FIRST`, `TIME_LAST`. The time column can be compared with date&time specified in format: `YYYY-mm-ddTHH:MM:SS.sss`, where `.sss` represents miliseconds and is an optional part (Ex. `2018-01-10T21:17:00`). Note that the timestamp should be in UTC timezone.
 
 ### Format
 #### Command line

--- a/unirecfilter/lib/functions.c
+++ b/unirecfilter/lib/functions.c
@@ -119,7 +119,7 @@ struct ast *newExpression(char *column, char *cmp, int64_t number, int is_signed
    struct expression *newast = (struct expression *) malloc(sizeof(struct expression));
 
    newast->type = NODE_T_EXPRESSION;
-   newast->column = strdup(column);
+   newast->column = column;
    newast->number = number;
    int id = ur_get_id_by_name(column);
    newast->is_signed = is_signed;
@@ -154,7 +154,7 @@ struct ast *newExpressionFP(char *column, char *cmp, double number)
    struct expression_fp *newast = (struct expression_fp *) malloc(sizeof(struct expression_fp));
 
    newast->type = NODE_T_EXPRESSION_FP;
-   newast->column = strdup(column);
+   newast->column = column;
    newast->number = number;
    int id = ur_get_id_by_name(column);
    newast->cmp = get_op_type(cmp);
@@ -178,7 +178,7 @@ struct ast *newExpressionDateTime(char *column, char *cmp, char *datetime)
    struct expression_datetime *newast = (struct expression_datetime *) malloc(sizeof(struct expression_datetime));
 
    newast->type = NODE_T_EXPRESSION_DATETIME;
-   newast->column = strdup(column);
+   newast->column = column;
 
    int id = ur_get_id_by_name(column);
    newast->cmp = get_op_type(cmp);
@@ -198,6 +198,7 @@ struct ast *newExpressionDateTime(char *column, char *cmp, char *datetime)
       printf("Error: %s could not be loaded. Expected format: YYYY-mm-ddTHH:MM:SS.sss, where .sss is optional. Eg. 2018-06-27T19:44:41.123.\n", datetime);
       newast->id = UR_INVALID_FIELD;
    }
+   free(datetime);
    return (struct ast *) newast;
 }
 
@@ -504,9 +505,7 @@ void freeAST(struct ast *ast)
    switch (ast->type) {
    case NODE_T_AST:
       freeAST(ast->l);
-      if (ast->r) {
-         freeAST(ast->r);
-      }
+      freeAST(ast->r);
       break;
    case NODE_T_EXPRESSION:
       free(((struct expression *) ast)->column);

--- a/unirecfilter/lib/functions.c
+++ b/unirecfilter/lib/functions.c
@@ -89,7 +89,7 @@ op_pair cmp_op_table[] = {
    { "~=", OP_RE }
 };
 
-cmp_op get_op_type( char* cmp ) {
+cmp_op get_op_type(char *cmp) {
    size_t table_size = sizeof(cmp_op_table) / sizeof(cmp_op_table[0]);
 
    for (op_pair *ptr = cmp_op_table; ptr < cmp_op_table + table_size; ptr++)
@@ -670,13 +670,13 @@ int evalAST(struct ast *ast, const ur_template_t *in_tmplt, const void *in_rec)
       cmp_op cmp = ((struct ip*) ast)->cmp;
 
       if (cmp_res == 0) {
-      // Same addresses
+         // Same addresses
          return cmp == OP_EQ || cmp == OP_LE || cmp == OP_GE;
       } else if (cmp_res < 0) {
-       // Address in record is lower than the given one
+         // Address in record is lower than the given one
          return cmp == OP_NE || cmp == OP_LT || cmp == OP_LE;
       } else {
-      // Address in record is higher than the given one
+         // Address in record is higher than the given one
          return cmp == OP_NE || cmp == OP_GT || cmp == OP_GE;
       }
    case NODE_T_STRING:

--- a/unirecfilter/lib/functions.h
+++ b/unirecfilter/lib/functions.h
@@ -60,7 +60,7 @@ memset(ur_get_ptr_by_id(tmpl, data, field_id), 0, ur_get_size(field_id));
 
 /* Used for types of expression nodes in abstract syntax tree */
 typedef enum { NODE_T_AST, NODE_T_EXPRESSION, NODE_T_EXPRESSION_FP,
-               NODE_T_PROTOCOL, NODE_T_IP, NODE_T_STRING,
+               NODE_T_EXPRESSION_DATETIME, NODE_T_PROTOCOL, NODE_T_IP, NODE_T_STRING,
                NODE_T_BRACKET, NODE_T_NEGATION } node_type;
 
 /* Used for describing comparison operators */
@@ -92,6 +92,14 @@ struct expression_fp {
    cmp_op cmp;
    char *column;
    double number;
+   ur_field_id_t id;
+};
+
+struct expression_datetime {
+   node_type type;
+   cmp_op cmp;
+   char *column;
+   ur_time_t date;
    ur_field_id_t id;
 };
 

--- a/unirecfilter/lib/parser.y
+++ b/unirecfilter/lib/parser.y
@@ -9,6 +9,7 @@
     struct ast *newAST(struct ast *l, struct ast *r, log_op operator);
     struct ast *newExpression(char *column, char *cmp, int64_t number, int is_signed);
     struct ast *newExpressionFP(char *column, char *cmp, double number);
+    struct ast *newExpressionDateTime(char *column, char *cmp, char *datetime);
     struct ast *newIP(char *column, char *cmp, char *ip);
     struct ast *newString(char *column, char *cmp, char *s);
     struct ast *newProtocol(char *cmp, char *data);
@@ -36,6 +37,7 @@
 %token <string> REGEX
 %token <string> PROTO_NAME
 %token <string> IP
+%token <string> DATETIME
 %token <string> STRING
 %token AND OR
 %token LEFT RIGHT PROTOCOL
@@ -63,6 +65,8 @@ exp:
     COLUMN CMP SIGNED { $$ = newExpression($1, $2, $3, 1); }
     | COLUMN CMP UNSIGNED { $$ = newExpression($1, $2, $3, 0); }
     | COLUMN CMP FLOAT { $$ = newExpressionFP($1, $2, $3); }
+    | COLUMN CMP DATETIME { $$ = newExpressionDateTime($1, $2, $3); }
+    | COLUMN EQ DATETIME { $$ = newExpressionDateTime($1, $2, $3); }
     | PROTOCOL CMP UNSIGNED { $$ = newExpression("PROTOCOL", $2, $3, 0); }
     | PROTOCOL EQ UNSIGNED { $$ = newExpression("PROTOCOL", $2, $3, 0); }
     | PROTOCOL EQ PROTO_NAME { $$ = (struct ast *) newProtocol($2, $3); }

--- a/unirecfilter/lib/scanner.l
+++ b/unirecfilter/lib/scanner.l
@@ -8,7 +8,7 @@
 
     char *copyString(char *str, int len) {
         char *ret = calloc(len + 1, sizeof(char));
-        strcpy(ret, str);
+        strncpy(ret, str, (size_t) len);
         return ret;
     }
     char *cutString(char *str, int len) {

--- a/unirecfilter/lib/scanner.l
+++ b/unirecfilter/lib/scanner.l
@@ -6,14 +6,14 @@
 
     #define YY_NO_INPUT
 
-    char *copyString(char* str, int len) {
-        char *ret = calloc(len+1, sizeof(char));
+    char *copyString(char *str, int len) {
+        char *ret = calloc(len + 1, sizeof(char));
         strcpy(ret, str);
         return ret;
     }
-    char *cutString(char* str, int len) {
+    char *cutString(char *str, int len) {
         char *ret = calloc(len-1, sizeof(char));
-        strncpy(ret, str+1, (size_t)len-2);
+        strncpy(ret, str + 1, (size_t) len - 2);
         return ret;
     }
 %}

--- a/unirecfilter/lib/scanner.l
+++ b/unirecfilter/lib/scanner.l
@@ -24,6 +24,7 @@ IPv4          {dec-octet}\.{dec-octet}\.{dec-octet}\.{dec-octet}
 h16     [0-9A-Fa-f]{1,4}
 ls32    {h16}:{h16}|{IPv4}
 IPv6    ({h16}:){6}{ls32}|::({h16}:){5}{ls32}|({h16})?::({h16}:){4}{ls32}|(({h16}:){0,1}{h16})?::({h16}:){3}{ls32}|(({h16}:){0,2}{h16})?::({h16}:){2}{ls32}|(({h16}:){0,3}{h16})?::{h16}:{ls32}|(({h16}:){0,4}{h16})?::{ls32}|(({h16}:){0,5}{h16})?::{h16}|(({h16}:){0,6}{h16})?::
+DATETIME [0-9]{4}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{2}:[0-9]{2}:[0-9]{2}|[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}
 
 %%
 
@@ -33,6 +34,8 @@ IPv6    ({h16}:){6}{ls32}|::({h16}:){5}{ls32}|({h16})?::({h16}:){4}{ls32}|(({h16
 "!"|"NOT"                                                { return NOT; }
 "||"|"OR"                                                { return OR; }
 "&&"|"AND"                                               { return AND; }
+{DATETIME}                                               { yylval.string = copyString(yytext, yyleng); return DATETIME; }
+\"({DATETIME})\"                                         { yylval.string = cutString(yytext, yyleng); return DATETIME; }
 -?[0-9]+\.[0-9]+                                         { sscanf(yytext, "%lf", &yylval.floating); return FLOAT; }
 -[0-9]+                                                  { sscanf(yytext, "%" SCNi64, &yylval.number); return SIGNED; }
 [0-9]+                                                   { sscanf(yytext, "%" SCNi64, &yylval.number); return UNSIGNED; }


### PR DESCRIPTION
From now, UniRec time fields can be compared with date&time constants.

This PR also contains some bugfixes.