### PR TITLE
Hotfix: Using of incorrect UniRec template in framework function.

### DIFF
--- a/aggregator/aggregator.cpp
+++ b/aggregator/aggregator.cpp
@@ -294,7 +294,7 @@ void process_agg_functions(ur_template_t *in_tmplt, const void *src_rec, ur_temp
  */
 void init_record_data(ur_template_t * in_tmplt, const void *src_rec, ur_template_t *out_tmplt, void *dst_rec)
 {
-   ur_clear_varlen(in_tmplt, dst_rec);
+   ur_clear_varlen(out_tmplt, dst_rec);
    // Copy all fields which are part of output template
    ur_copy_fields(out_tmplt, dst_rec, in_tmplt, src_rec);
    // Set initial value of module field(s)


### PR DESCRIPTION
Hotfix: Using of incorrect ur_template. 

In init_record() function when ur_clear_varlen() called, incorrect ur_template passed to function which could cause segmentation fault. Now using the right one suitable for the created record.