### PR TITLE
logreplay: fixed bug when logreplay did not terminate

### DIFF
--- a/logreplay/logreplay.cpp
+++ b/logreplay/logreplay.cpp
@@ -90,8 +90,13 @@ int verbose;
 
 void trap_default_signal_handler(int signal)
 {
+   static int sig_counter = 0;
    if (signal == SIGTERM || signal == SIGINT) {
       stop = 1;
+      sig_counter++;
+      if (sig_counter > 1) {
+         trap_terminate();
+      }
    }
 }
 


### PR DESCRIPTION
Logreplay did not properly terminate if there was connected a client
which was not receiving. The behavior was changed to:

First SIGINT: attempt to break the main loop and send EOF message to the connected client.
Second SIGINT: forcefully terminate libtrap and thus don't send EOF message to the connected client (useful if the client is not responding).