### PR TITLE
Overflow detection dedicated send

### DIFF
--- a/aggregator/agg_functions.cpp
+++ b/aggregator/agg_functions.cpp
@@ -87,3 +87,11 @@ void last_variable(const void *src, void *dst)
    var_params *params = (var_params*)dst;
    ur_set_var(OutputTemplate::out_tmplt, params->dst, params->field_id, src, params->var_len);
 }
+
+/* ================================================================= */
+/* ===================== No_check function ========================= */
+/* ================================================================= */
+int no_check(const void *a, const void *b)
+{
+   return 0;
+}

--- a/aggregator/agg_functions.h
+++ b/aggregator/agg_functions.h
@@ -46,6 +46,46 @@
 #ifndef AGGREGATOR_AGG_FUNCTIONS_H
 #define AGGREGATOR_AGG_FUNCTIONS_H
 
+#include <climits>
+#include "output.h"
+
+/**
+ * Control function which checks signed data type T overflow when doing addition.
+ * @tparam T Template type variable, have to be signed (eg. int).
+ * @param a [in] Pointer to first operand.
+ * @param b [in] Pointer to second operand.
+ * @return Return 0 when no overflow occurs, different value (mostly 1) otherwise.
+ */
+template<typename T>
+int check_safe_signed_add(const void *a, const void *b) {
+   //T, T
+   int bits = sizeof(T) * CHAR_BIT;
+   uint64_t r = (uint64_t)(*((T*)a)) + (uint64_t)(*((T*)b));
+   return (((uint64_t)(*((T*)a)) ^ r) & ((uint64_t)(*((T*)b)) ^ r)) >> (bits - 1);
+}
+
+/**
+ * Control function which checks unsigned data type T overflow when doing addition.
+ * @tparam T Template type variable, have to be unsigned (eg. uint).
+ * @param a [in] Pointer to first operand.
+ * @param b [in] Pointer to second operand.
+ * @return Return 0 when no overflow occurs, 1 otherwise.
+ */
+template<typename T>
+int check_safe_unsigned_add(const void *a, const void *b) {
+   T possible_result = *((T*)a) + *((T*)b);
+   return possible_result < *((T*)a);
+}
+
+/**
+ * Overflow check function which has to be used, when no overflow check needed.
+ * All params used only for function pointer compatibility, no other use.
+ * @param a [in] First operand.
+ * @param b [in] Second operand.
+ * @return Always return 0 meaning safe continue of agg func. processing.
+ */
+int no_check(const void *a, const void *b);
+
 /**
  * Makes sum of values stored on src and dst pointers from given type T.
  * @tparam T template type variable.

--- a/aggregator/configuration.cpp
+++ b/aggregator/configuration.cpp
@@ -41,6 +41,7 @@
  *
  */
 
+#include <utility>
 #include "configuration.h"
 
 Config::Config() : used_fields(0), timeout_type(TIMEOUT_ACTIVE), variable_flag(false)
@@ -121,9 +122,11 @@ bool Config::is_func(int index, int func_id)
    return false;
 }
 
-agg_func Config::get_function_ptr(int index, ur_field_type_t field_type)
+//agg_func Config::get_function_ptr(int index, ur_field_type_t field_type)
+std::pair<agg_func, check_func> Config::get_function_ptr(int index, ur_field_type_t field_type)
 {
-   agg_func out = &nope;
+   std::pair<agg_func, check_func> out (&nope, &no_check);
+
    if ((index < 0) || (index > used_fields - 1)) {
       return out;
    }
@@ -132,291 +135,299 @@ agg_func Config::get_function_ptr(int index, ur_field_type_t field_type)
       case SUM:
          switch (field_type) {
             case UR_TYPE_INT8:
-               out = &sum<int8_t>;
+               out.first = &sum<int8_t>;
+               out.second = &check_safe_signed_add<int8_t>;
                break;
             case UR_TYPE_INT16:
-               out = &sum<int16_t>;
+               out.first = &sum<int16_t>;
+               out.second = &check_safe_signed_add<int16_t>;
                break;
             case UR_TYPE_INT32:
-               out = &sum<int32_t>;
+               out.first = &sum<int32_t>;
+               out.second = &check_safe_signed_add<int32_t>;
                break;
             case UR_TYPE_INT64:
-               out = &sum<int64_t>;
+               out.first = &sum<int64_t>;
+               out.second = &check_safe_signed_add<int64_t>;
                break;
             case UR_TYPE_UINT8:
-               out = &sum<uint8_t>;
+               out.first = &sum<uint8_t>;
+               out.second = &check_safe_unsigned_add<uint8_t>;
                break;
             case UR_TYPE_UINT16:
-               out = &sum<uint16_t>;
+               out.first = &sum<uint16_t>;
+               out.second = &check_safe_unsigned_add<uint16_t>;
                break;
             case UR_TYPE_UINT32:
-               out = &sum<uint32_t>;
+               out.first = &sum<uint32_t>;
+               out.second = &check_safe_unsigned_add<uint32_t>;
                break;
             case UR_TYPE_UINT64:
-               out = &sum<uint64_t>;
+               out.first = &sum<uint64_t>;
+               out.second = &check_safe_unsigned_add<uint64_t>;
                break;
             case UR_TYPE_FLOAT:
-               out = &sum<float>;
+               out.first = &sum<float>;
                break;
             case UR_TYPE_DOUBLE:
-               out = &sum<double>;
+               out.first = &sum<double>;
                break;
             default:
                fprintf(stderr, "Only int, uint, float and double can use sum function, first assigned instead.\n");
-               out = &nope;
+               out.first = &nope;
          }
          break;
       case AVG:
          switch (field_type) {
             case UR_TYPE_INT8:
-               out = &avg<int8_t>;
+               out.first = &avg<int8_t>;
                break;
             case UR_TYPE_INT16:
-               out = &avg<int16_t>;
+               out.first = &avg<int16_t>;
                break;
             case UR_TYPE_INT32:
-               out = &avg<int32_t>;
+               out.first = &avg<int32_t>;
                break;
             case UR_TYPE_INT64:
-               out = &avg<int64_t>;
+               out.first = &avg<int64_t>;
                break;
             case UR_TYPE_UINT8:
-               out = &avg<uint8_t>;
+               out.first = &avg<uint8_t>;
                break;
             case UR_TYPE_UINT16:
-               out = &avg<uint16_t>;
+               out.first = &avg<uint16_t>;
                break;
             case UR_TYPE_UINT32:
-               out = &avg<uint32_t>;
+               out.first = &avg<uint32_t>;
                break;
             case UR_TYPE_UINT64:
-               out = &avg<uint64_t>;
+               out.first = &avg<uint64_t>;
                break;
             case UR_TYPE_FLOAT:
-               out = &avg<float>;
+               out.first = &avg<float>;
                break;
             case UR_TYPE_DOUBLE:
-               out = &avg<double>;
+               out.first = &avg<double>;
                break;
             default:
                fprintf(stderr, "Only int, uint, float and double can use avg function, first assigned instead.\n");
-               out = &nope;
+               out.first = &nope;
          }
          break;
       case MIN:
          switch (field_type) {
             case UR_TYPE_INT8:
-               out = &min<int8_t>;
+               out.first = &min<int8_t>;
                break;
             case UR_TYPE_INT16:
-               out = &min<int16_t>;
+               out.first = &min<int16_t>;
                break;
             case UR_TYPE_INT32:
-               out = &min<int32_t>;
+               out.first = &min<int32_t>;
                break;
             case UR_TYPE_INT64:
-               out = &min<int64_t>;
+               out.first = &min<int64_t>;
                break;
             case UR_TYPE_UINT8:
-               out = &min<uint8_t>;
+               out.first = &min<uint8_t>;
                break;
             case UR_TYPE_UINT16:
-               out = &min<uint16_t>;
+               out.first = &min<uint16_t>;
                break;
             case UR_TYPE_UINT32:
-               out = &min<uint32_t>;
+               out.first = &min<uint32_t>;
                break;
             case UR_TYPE_UINT64:
-               out = &min<uint64_t>;
+               out.first = &min<uint64_t>;
                break;
             case UR_TYPE_FLOAT:
-               out = &min<float>;
+               out.first = &min<float>;
                break;
             case UR_TYPE_DOUBLE:
-               out = &min<double>;
+               out.first = &min<double>;
                break;
             case UR_TYPE_CHAR:
-               out = &min<char>;
+               out.first = &min<char>;
                break;
             case UR_TYPE_TIME:
-               out = &min<uint64_t>;
+               out.first = &min<uint64_t>;
                break;
             case UR_TYPE_IP:
-               out = &min_ip;
+               out.first = &min_ip;
                break;
             default:
                fprintf(stderr, "Only fixed length fields can use min function, first assigned instead.\n");
-               out = &nope;
+               out.first = &nope;
          }
          break;
       case MAX:
          switch (field_type) {
             case UR_TYPE_INT8:
-               out = &max<int8_t>;
+               out.first = &max<int8_t>;
                break;
             case UR_TYPE_INT16:
-               out = &max<int16_t>;
+               out.first = &max<int16_t>;
                break;
             case UR_TYPE_INT32:
-               out = &max<int32_t>;
+               out.first = &max<int32_t>;
                break;
             case UR_TYPE_INT64:
-               out = &max<int64_t>;
+               out.first = &max<int64_t>;
                break;
             case UR_TYPE_UINT8:
-               out = &max<uint8_t>;
+               out.first = &max<uint8_t>;
                break;
             case UR_TYPE_UINT16:
-               out = &max<uint16_t>;
+               out.first = &max<uint16_t>;
                break;
             case UR_TYPE_UINT32:
-               out = &max<uint32_t>;
+               out.first = &max<uint32_t>;
                break;
             case UR_TYPE_UINT64:
-               out = &max<uint64_t>;
+               out.first = &max<uint64_t>;
                break;
             case UR_TYPE_FLOAT:
-               out = &max<float>;
+               out.first = &max<float>;
                break;
             case UR_TYPE_DOUBLE:
-               out = &max<double>;
+               out.first = &max<double>;
                break;
             case UR_TYPE_CHAR:
-               out = &max<char>;
+               out.first = &max<char>;
                break;
             case UR_TYPE_TIME:
-               out = &max<uint64_t>;
+               out.first = &max<uint64_t>;
                break;
             case UR_TYPE_IP:
-               out = &max_ip;
+               out.first = &max_ip;
                break;
             default:
                fprintf(stderr, "Only fixed length fields can use max function, first assigned instead.\n");
-               out = &nope;
+               out.first = &nope;
          }
          break;
       case FIRST:
          // Keep nope function because first value is set by copy from input record
-         out = &nope;
+         out.first = &nope;
          break;
       case LAST:
          switch (field_type) {
             case UR_TYPE_INT8:
-               out = &last<int8_t>;
+               out.first = &last<int8_t>;
                break;
             case UR_TYPE_INT16:
-               out = &last<int16_t>;
+               out.first = &last<int16_t>;
                break;
             case UR_TYPE_INT32:
-               out = &last<int32_t>;
+               out.first = &last<int32_t>;
                break;
             case UR_TYPE_INT64:
-               out = &last<int64_t>;
+               out.first = &last<int64_t>;
                break;
             case UR_TYPE_UINT8:
-               out = &last<uint8_t>;
+               out.first = &last<uint8_t>;
                break;
             case UR_TYPE_UINT16:
-               out = &last<uint16_t>;
+               out.first = &last<uint16_t>;
                break;
             case UR_TYPE_UINT32:
-               out = &last<uint32_t>;
+               out.first = &last<uint32_t>;
                break;
             case UR_TYPE_UINT64:
-               out = &last<uint64_t>;
+               out.first = &last<uint64_t>;
                break;
             case UR_TYPE_FLOAT:
-               out = &last<float>;
+               out.first = &last<float>;
                break;
             case UR_TYPE_DOUBLE:
-               out = &last<double>;
+               out.first = &last<double>;
                break;
             case UR_TYPE_CHAR:
-               out = &last<char>;
+               out.first = &last<char>;
                break;
             case UR_TYPE_TIME:
-               out = &last<uint64_t>;
+               out.first = &last<uint64_t>;
                break;
             case UR_TYPE_IP:
-               out = &last<ip_addr_t>;
+               out.first = &last<ip_addr_t>;
                break;
             case UR_TYPE_STRING:
-               out = &last_variable;
+               out.first = &last_variable;
                break;
             case UR_TYPE_BYTES:
-               out = &last_variable;
+               out.first = &last_variable;
                break;
             default:
                fprintf(stderr, "Type is not supported by current version of module, using first instead.\n");
-               out = &nope;
+               out.first = &nope;
          }
          break;
       case BIT_OR:
          switch (field_type) {
             case UR_TYPE_INT8:
-               out = &bitwise_or<int8_t>;
+               out.first = &bitwise_or<int8_t>;
                break;
             case UR_TYPE_INT16:
-               out = &bitwise_or<int16_t>;
+               out.first = &bitwise_or<int16_t>;
                break;
             case UR_TYPE_INT32:
-               out = &bitwise_or<int32_t>;
+               out.first = &bitwise_or<int32_t>;
                break;
             case UR_TYPE_INT64:
-               out = &bitwise_or<int64_t>;
+               out.first = &bitwise_or<int64_t>;
                break;
             case UR_TYPE_UINT8:
-               out = &bitwise_or<uint8_t>;
+               out.first = &bitwise_or<uint8_t>;
                break;
             case UR_TYPE_UINT16:
-               out = &bitwise_or<uint16_t>;
+               out.first = &bitwise_or<uint16_t>;
                break;
             case UR_TYPE_UINT32:
-               out = &bitwise_or<uint32_t>;
+               out.first = &bitwise_or<uint32_t>;
                break;
             case UR_TYPE_UINT64:
-               out = &bitwise_or<uint64_t>;
+               out.first = &bitwise_or<uint64_t>;
                break;
             case UR_TYPE_CHAR:
-               out = &bitwise_or<char>;
+               out.first = &bitwise_or<char>;
                break;
             default:
                fprintf(stderr, "Only int, uint and char can use bitwise functions, first assigned instead.\n");
-               out = &nope;
+               out.first = &nope;
          }
          break;
       case BIT_AND:
          switch (field_type) {
             case UR_TYPE_INT8:
-               out = &bitwise_and<int8_t>;
+               out.first = &bitwise_and<int8_t>;
                break;
             case UR_TYPE_INT16:
-               out = &bitwise_and<int16_t>;
+               out.first = &bitwise_and<int16_t>;
                break;
             case UR_TYPE_INT32:
-               out = &bitwise_and<int32_t>;
+               out.first = &bitwise_and<int32_t>;
                break;
             case UR_TYPE_INT64:
-               out = &bitwise_and<int64_t>;
+               out.first = &bitwise_and<int64_t>;
                break;
             case UR_TYPE_UINT8:
-               out = &bitwise_and<uint8_t>;
+               out.first = &bitwise_and<uint8_t>;
                break;
             case UR_TYPE_UINT16:
-               out = &bitwise_and<uint16_t>;
+               out.first = &bitwise_and<uint16_t>;
                break;
             case UR_TYPE_UINT32:
-               out = &bitwise_and<uint32_t>;
+               out.first = &bitwise_and<uint32_t>;
                break;
             case UR_TYPE_UINT64:
-               out = &bitwise_and<uint64_t>;
+               out.first = &bitwise_and<uint64_t>;
                break;
             case UR_TYPE_CHAR:
-               out = &bitwise_and<char>;
+               out.first = &bitwise_and<char>;
                break;
             default:
                fprintf(stderr, "Only int, uint and char can use bitwise functions, first assigned instead.\n");
-               out = &nope;
+               out.first = &nope;
          }
          break;
    }

--- a/aggregator/configuration.h
+++ b/aggregator/configuration.h
@@ -147,9 +147,9 @@ public:
      * Return function implementation to assigned function type of field on given index.
      * @param [in] index of field to ask for function implementation.
      * @param [in] field_type of field on given index (type returned from ur_get_type()0.
-     * @return Pointer to function which implements the assigned aggregation function type.
+     * @return Pair of pointers to function which implements the assigned aggregation function type and its overflow check function.
      */
-   agg_func get_function_ptr(int index, ur_field_type_t field_type);
+   std::pair<agg_func, check_func> get_function_ptr(int index, ur_field_type_t field_type);
     /**
      * Return function implementation of specified field type for record postprocessing before sending.
      * @param [in] index of field to ask for function implementation.

--- a/aggregator/output.cpp
+++ b/aggregator/output.cpp
@@ -56,16 +56,18 @@
 ur_template_t *OutputTemplate::out_tmplt = NULL;
 int OutputTemplate::indexes_to_record [MAX_KEY_FIELDS];
 agg_func (OutputTemplate::process[MAX_KEY_FIELDS]);
+check_func (OutputTemplate::check[MAX_KEY_FIELDS]);
 int OutputTemplate::used_fields = 0;
 bool OutputTemplate::prepare_to_send = false;
 final_avg OutputTemplate::avg_fields[MAX_KEY_FIELDS];
 
 /* ----------------------------------------------------------------- */
-void OutputTemplate::add_field(int record_id, agg_func foo, bool avg, final_avg foo2)
+void OutputTemplate::add_field(int record_id, agg_func foo, check_func foo2, bool avg, final_avg foo3)
 {
    indexes_to_record[used_fields] = record_id;
    process[used_fields] = foo;
-   avg_fields[used_fields] = foo2;
+   check[used_fields] = foo2;
+   avg_fields[used_fields] = foo3;
    // If avg used for the first time set prepare_to_send flag
    if (!prepare_to_send && avg) {
       prepare_to_send = true;

--- a/aggregator/output.h
+++ b/aggregator/output.h
@@ -58,6 +58,11 @@ typedef void (*agg_func)(const void *src, void *dst);
  * Define pointer to make_avg function template.
  */
 typedef void (*final_avg)(void *record, uint32_t count);
+/**
+ * Overflow check function pointer type definition.
+ * Defines pointer to check_safe_signed_add, check_safe_unsigned_add, no_check function templates.
+ */
+typedef int (*check_func)(const void *a, const void *b);
 
 /**
  * Class to represent template for output records and its fields processing.
@@ -70,6 +75,7 @@ public:
    static agg_func process[MAX_KEY_FIELDS];           /*!< Pointer to aggregation function of field data type. */
    static bool prepare_to_send;                       /*!< Flag is record postprocessing required by assigned aggregation function. */
    static final_avg avg_fields[MAX_KEY_FIELDS];       /*!< Pointer to postprocessing function for average function of field data type. */
+   static check_func check[MAX_KEY_FIELDS];           /*!< Pointer to overflow check function for given process operation. */
 
    /**
     * Assign field with all required parameters to template.
@@ -78,7 +84,7 @@ public:
     * @param [in] avg_flag whether the field has avg function assigned.
     * @param [in] foo2 pointer to postprocessing average function or NULL instead.
     */
-   static void add_field(int record_id, agg_func foo, bool avg_flag, final_avg foo2);
+   static void add_field(int record_id, agg_func foo, check_func foo2, bool avg_flag, final_avg foo3);
    /**
     * Reset all fields to default (empty) state.
     */

--- a/aggregator/run_test.sh
+++ b/aggregator/run_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Start aggregator itself and store its PID into variable
+/home/slabimic/Nemea/Nemea-Modules/aggregator/agg -i u:input_data,u:aggr_data -k SRC_IP -k DST_IP -s BYTES -s PACKETS -t a:60 & 
+PID=$!
+
+# Start logger to pickup aggregated data from unix socket to not to block the interface
+/usr/bin/nemea/logger -t -i u:aggr_data >/dev/null &
+
+# Start repeater with source data to send as input to aggregator
+/usr/bin/nemea/traffic_repeater -i f:/home/slabimic/Nemea_data/data.trapcap.*,u:input_data
+
+# Send ^C signal to aggregation module and wait to close (complete processing and flush storage)
+kill -s 2 $PID
+
+# Wait a bit to gracefully close the aggregation module (when global timeout its good to wait the TIMEOUT_LENGTH + at least second more)
+sleep 2;


### PR DESCRIPTION
New feature: **Record sending with a dedicated thread.**

Interface settings or network properties like latency can affect the throughput of the module processing. A new dedicated thread was implemented for that case and has its own dedicated data space for records (messages) to send. This improves the processing power because sending the record (message) is no longer the task of processing thread. 

The processing thread only "mark_msg_to_send"  which moves the record to the data space of sending thread and continue processing another received record.