### PR TITLE
build: update Makefile.am for logger&topn - enforce C std

### DIFF
--- a/logger/Makefile.am
+++ b/logger/Makefile.am
@@ -2,6 +2,7 @@ bin_PROGRAMS=logger
 dist_bin_SCRIPTS=csv2nf.sh
 logger_SOURCES=logger.c fields.c fields.h
 logger_LDADD=-lunirec -ltrap -lpthread
+logger_CFLAGS=-std=gnu99
 pkgdocdir=${docdir}/logger
 pkgdoc_DATA=README.md
 EXTRA_DIST=README.md csv2nf.sh

--- a/topn/Makefile.am
+++ b/topn/Makefile.am
@@ -2,6 +2,7 @@ ACLOCAL_AMFLAGS = -I m4
 bin_PROGRAMS=topn
 topn_SOURCES=topn.c topn.h fields.c fields.h twister.h
 topn_LDADD=-lunirec -ltrap -lnemea-common
+topn_CFLAGS=-std=gnu99
 EXTRA_DIST=README.md
 pkgdocdir=$(docdir)/topn
 pkgdoc_DATA=README.md


### PR DESCRIPTION
ccache fails on C99 construct by default (tested on Fedora29, ccache
3.4.2, during compilation of Turris Omnia packages).
That's why we should specify right standard for modules that use
features like:

```
for (int i = 0; i < size; i++) {
```

if we want to compile them on multiple platforms.