### PR TITLE
prefix_tags: add libtrap as a linker dependency

### DIFF
--- a/prefix_tags/Makefile.am
+++ b/prefix_tags/Makefile.am
@@ -21,7 +21,7 @@ test_prefix_tags_SOURCES = \
 	test_prefix_tags.c \
 	prefix_tags_functions.c prefix_tags_functions.h
 
-test_prefix_tags_LDADD=-lunirec
+test_prefix_tags_LDADD=-ltrap -lunirec
 
 include ../aminclude.am
 


### PR DESCRIPTION
Bugfix: Fix failed compilation of `test_prefix_tags` due to missing `libtrap` linker dependency.

This adds `-ltrap` to the `test_prefix_tags_LDADD` environmental variable in `prefix_tags/Makefile.am`, which is needed by `ur_set_output_template(ifc, tmplt)` defined in `#include <unirec/unirec.h>`.

Without the `libtrap`, the linking fails with the following output:
```
  CCLD     prefix_tags
prefix_tags_functions.o: In function `update_output_format':
/home/paulos/sources/Nemea-Modules/prefix_tags/prefix_tags_functions.c:33: undefined reference to `trap_get_global_ctx'
//usr/local/lib/libunirec.a(libunirec_la-unirec.o): In function `ur_ctx_set_output_template':
/home/paulos/sources/Nemea-Framework/unirec/unirec.c:786: undefined reference to `trap_ctx_set_data_fmt'
//usr/local/lib/libunirec.a(libunirec_la-unirec.o): In function `ur_ctx_set_input_template':
/home/paulos/sources/Nemea-Framework/unirec/unirec.c:805: undefined reference to `trap_ctx_set_required_fmt'
//usr/local/lib/libunirec.a(libunirec_la-unirec.o): In function `ur_ctx_create_bidirectional_template':
/home/paulos/sources/Nemea-Framework/unirec/unirec.c:829: undefined reference to `trap_ctx_set_required_fmt'
/home/paulos/sources/Nemea-Framework/unirec/unirec.c:830: undefined reference to `trap_ctx_set_data_fmt'
collect2: error: ld returned 1 exit status
Makefile:686: recipe for target 'test_prefix_tags' failed
```