### PR TITLE
report2idea: warden_filer wrapper

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,7 @@ AC_CONFIG_FILES([Makefile
                  report2idea/venom/Makefile
                  report2idea/voipfraud/Makefile
                  report2idea/vportscan/Makefile
+                 report2idea/warden_filer/Makefile
                  resolver/Makefile
                  scalar-aggregator/Makefile
                  topn/Makefile

--- a/nemea-modules.spec.in
+++ b/nemea-modules.spec.in
@@ -102,6 +102,7 @@ ldconfig
 %{_bindir}/nemea/venom2idea.py
 %{_bindir}/nemea/voipfraud2idea.py
 %{_bindir}/nemea/vportscan2idea.py
+%{_bindir}/nemea/nemea_warden_filer
 %{_docdir}/nemea-modules/*/*
 %config(noreplace) %{_sysconfdir}/nemea/email_reporter/example.cfg
 %config(noreplace) %{_sysconfdir}/nemea/email_reporter/generic.cfg

--- a/report2idea/Makefile.am
+++ b/report2idea/Makefile.am
@@ -11,6 +11,7 @@ SUBDIRS=hoststats \
 		haddrscan \
 		sipbruteforce \
 		amplificationdetector \
+		warden_filer \
 		minerdetector
 
 EXTRA_DIST=template.py test.sh config.yml.example ${bin_SCRIPTS}

--- a/report2idea/warden_filer/Makefile.am
+++ b/report2idea/warden_filer/Makefile.am
@@ -1,0 +1,2 @@
+dist_bin_SCRIPTS=nemea_warden_filer
+

--- a/report2idea/warden_filer/nemea_warden_filer
+++ b/report2idea/warden_filer/nemea_warden_filer
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Author: Tomas Cejka <cejkat@cesnet.cz>
+#
+
+helpstring="$0 -w <warden_config.cfg> -c <reporters_config.yml> [-dvh] [-n filername]
+
+This script takes warden_client.cfg configuration file (warconf) and
+reporters_config.yml configuration file (repconf) given as arguments (see help
+-h), the 'namespace' information is extracted from repconf, and all occurencies
+of 'name' or 'Name' in warconf are replaced with the 'namespace'.'filername'.
+(default 'filername': filer).
+
+The aim of this wrapper is to use 'namespace' configured on one place in
+repconf.
+
+Finally after modification of warconf, warden_filer.py is executed (i.e. it
+must be present somewhere in PATH) as a sender with warconf.
+
+Additional options:
+-d   debug - do not execute warden_filer, do not modify warconf
+-h   show this help
+-n   filername, default is set to "filer"
+-v   verbose - print additional information (values of some internal variables)
+"
+
+PATH="$PATH:/usr/bin/nemea/"
+
+# path to warden_filer
+warden_filer="$(which warden_filer.py 2> /dev/null)"
+
+# control variables
+verbose=0
+debug=0
+name="filer"
+
+# parse options, c ~ repconf, w ~ warconf, v ~ verbose, d ~ debug - don't run,
+# n ~ filername, h ~ help
+while getopts w:c:n:vdh NAME; do
+   case "$NAME" in
+      c) repconf="$OPTARG" ;;
+      w) warconf="$OPTARG" ;;
+      v) verbose=1 ;;
+      d) debug=1 ;;
+      n) name="$OPTARG" ;;
+      h) echo "$helpstring"; exit 1 ;;
+   esac
+done
+
+if [ -z "$repconf" -o -z "$warconf" ]; then
+   echo "Error, -w and -c options are mandatory." >&2
+   exit 1
+fi
+
+if [ -z "$warden_filer" ]; then
+   echo "Missing warden_filer.py, its installation is needed." >&2
+   exit 1
+fi
+
+# set control variables to skip execution and avoid modification
+if [ "$debug" -eq 1 ]; then
+   PRINT=echo
+   SEDMOD=""
+else
+   PRINT=""
+   SEDMOD="-i"
+fi
+
+if [ "$verbose" -eq 1 ]; then
+   echo repconf="$repconf"
+   echo warconf="$warconf"
+fi
+
+# extract namespace from repconf, e.g., from "namespace: com.example.nemea"
+namespace="$(sed -n 's/^namespace:\s*\(.*\)/\1/p' "$repconf")"
+
+if [ "$verbose" -eq 1 ]; then
+   echo namespace="$namespace"
+fi
+
+# modify warconf to set new name
+sed $SEDMOD 's/^\(\s*\)\("[nN]ame":\s*\)"[^"]*"\(.*\)/\1\2"'"$namespace.$name"'"\3/' "$warconf"
+
+# execute warden_filer.py
+$PRINT exec "$warden_filer" -c "$warconf" sender
+

--- a/report2idea/warden_filer/nemea_warden_filer
+++ b/report2idea/warden_filer/nemea_warden_filer
@@ -72,8 +72,18 @@ if [ "$verbose" -eq 1 ]; then
    echo warconf="$warconf"
 fi
 
+if [ ! -r "$repconf" ]; then
+   echo "Cannot open $repconf. File is missing or permissions prevents from reading." >&2
+   exit 1
+fi
+
 # extract namespace from repconf, e.g., from "namespace: com.example.nemea"
-namespace="$(sed -n 's/^namespace:\s*\(.*\)/\1/p' "$repconf")"
+namespace="$(sed -n 's/^namespace:\s*'"[\"']"'\?\('"[^\"']"'*\).*/\1/p' "$repconf")"
+
+if [ -z "$namespace" ]; then
+   echo "Missing 'namespace' in the $repconf file." >&2
+   exit 1
+fi
 
 if [ "$verbose" -eq 1 ]; then
    echo namespace="$namespace"


### PR DESCRIPTION
Add new shell script - a wrapper for warden_filer so we can use
namespace configured in the common configuration file of reporter
modules.
The script (nemea_warden_filer) rewrites `Name` and `name` in the given
warden_client configuration file and executes warden_filer.py as a
sender.