### PR TITLE
Repair merger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ unirecfilter/lib/lex.yy.c
 unirecfilter/lib/liburfilter.pc
 unirecfilter/lib/parser.tab.c
 unirecfilter/lib/parser.tab.h
+merger/merger

--- a/merger/merger.c
+++ b/merger/merger.c
@@ -161,7 +161,7 @@ void *capture_thread(void *arg)
    } // end while(!stop && !private_stop)
 
    if (verbose >= 1) {
-      printf("Thread %i exitting.\n", index);
+      printf("Thread %i exiting.\n", index);
    }
 
    pthread_exit(NULL);
@@ -357,7 +357,7 @@ int main(int argc, char **argv)
 
    // ***** Cleanup *****
    if (verbose >= 0) {
-      fprintf(stderr, "Exitting ...\n");
+      fprintf(stderr, "Exiting ...\n");
    }
 
    if (!noeof) {

--- a/merger/merger.c
+++ b/merger/merger.c
@@ -111,7 +111,7 @@ void *capture_thread(void *arg)
          const char *spec = NULL;
          if (trap_get_data_fmt(TRAPIFC_INPUT, index, &data_fmt, &spec) != TRAP_E_OK) {
             fprintf(stderr, "Data format was not loaded.");
-            goto unlock_exit;
+            goto unlock_thread_exit;
          } else {
             if (out_rec != NULL) {
                free(out_rec);
@@ -121,13 +121,13 @@ void *capture_thread(void *arg)
             in_template[index] = ur_define_fields_and_update_template(spec, in_template[index]);
             if (in_template[index] == NULL) {
                fprintf(stderr, "Template could not be edited");
-               goto unlock_exit;
+               goto unlock_thread_exit;
             } else {
                out_template = ur_expand_template(spec, out_template);
                char *spec_cpy = ur_template_string(out_template);
                if (spec_cpy == NULL) {
                   fprintf(stderr, "Memory allocation problem.");
-                  goto unlock_exit;
+                  goto unlock_thread_exit;
                }
                trap_set_data_fmt(0, TRAP_FMT_UNIREC, spec_cpy);
             }
@@ -135,7 +135,7 @@ void *capture_thread(void *arg)
             out_rec = ur_create_record(out_template, UR_MAX_SIZE);
             if (out_rec == NULL) {
                fprintf(stderr, "ERROR: Allocation of record failed.\n");
-               goto unlock_exit;
+               goto unlock_thread_exit;
             }
          }
       } else {
@@ -167,7 +167,7 @@ void *capture_thread(void *arg)
    pthread_exit(NULL);
    return NULL;
 
-unlock_exit:
+unlock_thread_exit:
    pthread_mutex_unlock(&unirec_mutex);
    pthread_exit(NULL);
    return NULL;

--- a/merger/merger.c
+++ b/merger/merger.c
@@ -292,7 +292,7 @@ int main(int argc, char **argv)
 
    // Create input and output UniRec template
 
-   in_template = (ur_template_t **) calloc(sizeof(ur_template_t *), module_info->num_ifc_in);
+   in_template = (ur_template_t **) calloc(module_info->num_ifc_in, sizeof(ur_template_t *));
    if (in_template == NULL) {
       fprintf(stderr, "Error: allocation of templates failed.\n");
       ret = -1;

--- a/merger/merger.c
+++ b/merger/merger.c
@@ -36,7 +36,7 @@ trap_module_info_t *module_info = NULL;
 #define MODULE_PARAMS(PARAM) \
   PARAM('u', "unirec", "UniRec specifier of input/output data (same to all links). (default <COLLECTOR_FLOW>).", required_argument, "string") \
   PARAM('n', "noeof", "Do not send termination message.", no_argument, "none") \
-  PARAM('I', "ignore-in-eof", "Do not terminate on incomming termination message.", no_argument, "none") \
+  PARAM('I', "ignore-in-eof", "Do not terminate on incomming termination message.", no_argument, "none")
 
 static int stop = 0;
 static int verbose;

--- a/merger/merger.c
+++ b/merger/merger.c
@@ -73,6 +73,9 @@ void *capture_thread(void *arg)
       fprintf(stderr, "Thread %i started.\n", index);
    }
 
+   // Create unirec input template for current thread.
+   in_template[index] = ur_create_input_template(0, NULL, NULL);
+
    /* Receive first message to get sent data format and extend output
     * template. */
    trap_set_required_fmt(index, TRAP_FMT_UNIREC, "");
@@ -290,8 +293,6 @@ int main(int argc, char **argv)
       printf("Creating UniRec templates ...\n");
    }
 
-   // Create input and output UniRec template
-
    in_template = (ur_template_t **) calloc(module_info->num_ifc_in, sizeof(ur_template_t *));
    if (in_template == NULL) {
       fprintf(stderr, "Error: allocation of templates failed.\n");
@@ -306,6 +307,7 @@ int main(int argc, char **argv)
       printf("Initialization done.\n");
    }
 
+   // Create output UniRec template
    out_template = NULL;
 
    /* Start with user-defined template given by -u parameter */

--- a/merger/merger.c
+++ b/merger/merger.c
@@ -134,7 +134,7 @@ void *capture_thread(void *arg)
 
             out_rec = ur_create_record(out_template, UR_MAX_SIZE);
             if (out_rec == NULL) {
-               fprintf(stderr, "ERROR: Allocation of record\n");
+               fprintf(stderr, "ERROR: Allocation of record failed.\n");
                goto unlock_exit;
             }
          }
@@ -253,7 +253,7 @@ int main(int argc, char **argv)
 
    in_template = (ur_template_t **) calloc(sizeof(ur_template_t *), module_info->num_ifc_in);
    if (in_template == NULL) {
-      fprintf(stderr, "Error: allocation of templates.\n");
+      fprintf(stderr, "Error: allocation of templates failed.\n");
       ret = -1;
       goto exit;
    }

--- a/merger/merger.c
+++ b/merger/merger.c
@@ -385,3 +385,7 @@ exit:
 
    return ret;
 }
+
+// Local variables:
+// c-basic-offset: 3;
+// End:


### PR DESCRIPTION
This pull request (in particular commit 1ac29dd) needs a thorough review as i haven't really worked with threading in c before.

I use the merger module after our haddrscandetectors so it sees very little traffic and some interfaces can be entirely quiet. I think that the redesigned merger suffers from starvation in these conditions. At least it wouldn't say is-conn on all input interfaces before i moved the initial recv to the threads for this pull request and we never saw any alerts.

While these changes are a definite improvement in our environment i don't think it is as stable as the previous merger written with openmp yet.