### PR TITLE
blacklist2idea: Simplify the nonvalid XML condition

### DIFF
--- a/report2idea/blacklist/blacklist2idea.py
+++ b/report2idea/blacklist/blacklist2idea.py
@@ -247,8 +247,8 @@ def load_blacklists(config):
     ip_root_element = tree.find(".//array[@type='IP']")
     url_dns_root_element = tree.find(".//array[@type='URL/DNS']")
 
-    ip_blacklists = list(ip_root_element) if ip_root_element is not None and len(ip_root_element) else list()
-    url_dns_blacklists = list(url_dns_root_element) if url_dns_root_element is not None and len(url_dns_root_element) else list()
+    ip_blacklists = list(ip_root_element) if ip_root_element else list()
+    url_dns_blacklists = list(url_dns_root_element) if url_dns_root_element else list()
 
     for blacklists in [ip_blacklists, url_dns_blacklists]:
         bl_type = 'ip' if blacklists is ip_blacklists else 'url_dns'


### PR DESCRIPTION
* In 3c7ebb2e2ad34889a0d49e9949f58825b572f618 a hotfix was created
  for nonvalid blacklist hostname and URL representation. The condition
  used there was (x is not None and len(x)), which is equivalent
  to (x) as both None and iterable of length 0 are treated as False.
  The simplified condition works exactly the same in these cases. There
  still remains the case of non-iterables, where the code will fail
  (as list cannot be constructed from non-iterables), but the previous
  would also. To be extra safe there, one should do like
  try: y = list(x); except TypeError: y = list(); but according to [1],
  xml.etree.ElementTree.parse() should return ElementTree instance which
  should only evaluate to iterable or None when passed to list constructor,
  so y = list(x) if (x) else list(); is probably enough. Based on [1],
  xml.etree.ElementTree is not safe for untrusted data anyways.
* Well, writing robust code in Python is hard.

[1] https://docs.python.org/3.8/library/xml.etree.elementtree.html