### PR TITLE
unirecfilter: "In Array" feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
    #- export PATH=$(pyenv prefix)/bin:$PATH
    - sudo pip3 install ply
    - sudo pip3 install PyYAML pynspect
-   - ( git clone --depth 2 -q https://github.com/CESNET/nemea-framework nf; cd nf; ./bootstrap.sh && ./configure -q --prefix=/usr --bindir=/usr/bin/nemea && make -j10 && sudo make install; (cd pytrap && sudo python3 setup.py install;); (cd pycommon && sudo python3 setup.py install;); )
+   - ( git clone --depth 2 -q https://github.com/CESNET/nemea-framework nf; cd nf; ./bootstrap.sh && ./configure -q --prefix=/usr --bindir=/usr/bin/nemea && make -j10 && sudo make install; (cd pytrap && sudo python3 setup.py install;); (cd pycommon && sudo pip3 install --upgrade MarkupSafe; sudo python3 setup.py install;); )
    - sudo rm -rf nemea-framework
    - python3 -c 'import pytrap'
    - grep -e '\<22/tcp' -e '\<23/tcp' -e '\<2179/tcp' -e '\<5900/tcp' /etc/services

--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,8 @@ NEMEA_FRAMEWORK_LIBS=${LIBS}
 AC_SUBST(NEMEA_FRAMEWORK_LIBS)
 #LIBS=${backup_libs}
 
+PKG_CHECK_MODULES([cmocka], [cmocka], [have_cmocka="yes"], [have_cmocka="no"])
+AM_CONDITIONAL([HAVE_CMOCKA], [test x$have_cmocka = xyes])
 
 AC_ARG_WITH([openssl],
         [AS_HELP_STRING([--without-openssl], [Force to disable openssl])],

--- a/unirecfilter/README.md
+++ b/unirecfilter/README.md
@@ -49,6 +49,7 @@ Available comparison operators are:
 - `=`, `==` equal/matches subnet
 - `!=`, `<>` not equal
 - `=~`, `~=` matches regular expression
+- `in`, `IN` In-Array function, see the "In Array" section below
 
 Available logical operators are:
 
@@ -100,6 +101,25 @@ IP address) because it is masked during the initiation of the filter
 
 Operator `==` returns true if and only if an `SRC_IP` belong to the
 given subnet.
+
+**In Array**
+
+It is possible to abbreviate (and optimize) filter when a field is match
+with a set values.
+For example, it is possible to rewrite this:
+
+`DST_PORT == 1 or DST_PORT == 234 or DST_PORT == 123 or DST_PORT == 80 or DST_PORT == 443`
+
+into more readable this:
+
+`DST_PORT in [1, 234, 123, 80, 443]`
+
+Internally, the array (which is specified in brackets `[` and `]`) is parsed, sorted,
+and the filter matching is done using binary search, i.e., it is faster
+according to measurement (mainly for longer arrays).
+
+These UniRec types are currently supported by this In Array feature:
+`int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, `uint64`, `ipaddr`, `time`, `float`, `double`
 
 ### Format
 

--- a/unirecfilter/lib/Makefile.am
+++ b/unirecfilter/lib/Makefile.am
@@ -1,7 +1,7 @@
 FLEX = flex
 BISON = bison
 include ../../aminclude.am
-EXTRA_DIST=parser.y scanner.l
+EXTRA_DIST=parser.y scanner.l test_liburfilter.c
 
 lib_LTLIBRARIES = liburfilter.la
 include_HEADERS = liburfilter.h
@@ -32,4 +32,10 @@ parser.tab.c: parser.y
 clean-local:
 	rm -f lex.yy.c parser.tab.c parser.tab.h parser fiedls.c fields.h
 
+if HAVE_CMOCKA
+check_PROGRAMS=test_liburfilter
+test_liburfilter_SOURCES=test_liburfilter.c
+test_liburfilter_LDADD=-lcmocka -lurfilter
+TESTS=test_liburfilter
+endif
 

--- a/unirecfilter/lib/functions.h
+++ b/unirecfilter/lib/functions.h
@@ -110,7 +110,11 @@ struct expression_array {
    char *column;
    uint32_t array_size;
    uint64_t *array_values;
+   ip_addr_t *array_values_ip;
+   ur_time_t *array_values_date;
+   double *array_values_double;
    ur_field_id_t id;
+   ur_field_type_t field_type;
 };
 
 struct protocol {

--- a/unirecfilter/lib/functions.h
+++ b/unirecfilter/lib/functions.h
@@ -60,11 +60,12 @@ memset(ur_get_ptr_by_id(tmpl, data, field_id), 0, ur_get_size(field_id));
 
 /* Used for types of expression nodes in abstract syntax tree */
 typedef enum { NODE_T_AST, NODE_T_EXPRESSION, NODE_T_EXPRESSION_FP,
-               NODE_T_EXPRESSION_DATETIME, NODE_T_PROTOCOL, NODE_T_IP, NODE_T_NET, NODE_T_STRING,
+               NODE_T_EXPRESSION_DATETIME, NODE_T_EXPRESSION_ARRAY,
+               NODE_T_PROTOCOL, NODE_T_IP, NODE_T_NET, NODE_T_STRING,
                NODE_T_BRACKET, NODE_T_NEGATION } node_type;
 
 /* Used for describing comparison operators */
-typedef enum { OP_EQ, OP_NE, OP_LT, OP_LE, OP_GT, OP_GE, OP_RE /* regex match */, OP_INVALID } cmp_op;
+typedef enum { OP_EQ, OP_NE, OP_LT, OP_LE, OP_GT, OP_GE, OP_RE /* regex match */, OP_IN, OP_INVALID } cmp_op;
 
 /* Used for describing logical operators */
 typedef enum { OP_AND, OP_OR, OP_NOP } log_op;
@@ -100,6 +101,15 @@ struct expression_datetime {
    cmp_op cmp;
    char *column;
    ur_time_t date;
+   ur_field_id_t id;
+};
+
+struct expression_array {
+   node_type type;
+   cmp_op cmp;
+   char *column;
+   uint32_t array_size;
+   uint64_t *array_values;
    ur_field_id_t id;
 };
 

--- a/unirecfilter/lib/parser.y
+++ b/unirecfilter/lib/parser.y
@@ -71,9 +71,9 @@ exp:
     | COLUMN CMP FLOAT { $$ = newExpressionFP($1, $2, $3); }
     | COLUMN CMP DATETIME { $$ = newExpressionDateTime($1, $2, $3); }
     | COLUMN EQ DATETIME { $$ = newExpressionDateTime($1, $2, $3); }
-    | COLUMN CMP ARRAY { $$ = newExpressionArray($1, $2, $3); }
-    | PROTOCOL CMP UNSIGNED { $$ = newExpression("PROTOCOL", $2, $3, 0); }
-    | PROTOCOL EQ UNSIGNED { $$ = newExpression("PROTOCOL", $2, $3, 0); }
+    | COLUMN CMP ARRAY { $$ = newExpressionArray($1, $2, $3); if ($$ == NULL) {YYERROR;}}
+    | PROTOCOL CMP UNSIGNED { $$ = newExpression(strdup("PROTOCOL"), $2, $3, 0); }
+    | PROTOCOL EQ UNSIGNED { $$ = newExpression(strdup("PROTOCOL"), $2, $3, 0); }
     | PROTOCOL EQ PROTO_NAME { $$ = (struct ast *) newProtocol($2, $3); }
     | PROTOCOL EQ STRING { $$ = (struct ast *) newProtocol($2, $3); }
     | COLUMN EQ IP { $$ = (struct ast *) newIP($1, $2, $3); }

--- a/unirecfilter/lib/parser.y
+++ b/unirecfilter/lib/parser.y
@@ -10,6 +10,7 @@
     struct ast *newExpression(char *column, char *cmp, int64_t number, int is_signed);
     struct ast *newExpressionFP(char *column, char *cmp, double number);
     struct ast *newExpressionDateTime(char *column, char *cmp, char *datetime);
+    struct ast *newExpressionArray(char *column, char *cmp, char *array);
     struct ast *newIP(char *column, char *cmp, char *ip);
     struct ast *newIPNET(char *column, char *cmp, char *ipAddr);
     struct ast *newString(char *column, char *cmp, char *s);
@@ -39,6 +40,7 @@
 %token <string> PROTO_NAME
 %token <string> IP
 %token <string> DATETIME
+%token <string> ARRAY
 %token <string> STRING
 %token <string> NET
 %token AND OR
@@ -69,6 +71,7 @@ exp:
     | COLUMN CMP FLOAT { $$ = newExpressionFP($1, $2, $3); }
     | COLUMN CMP DATETIME { $$ = newExpressionDateTime($1, $2, $3); }
     | COLUMN EQ DATETIME { $$ = newExpressionDateTime($1, $2, $3); }
+    | COLUMN CMP ARRAY { $$ = newExpressionArray($1, $2, $3); }
     | PROTOCOL CMP UNSIGNED { $$ = newExpression("PROTOCOL", $2, $3, 0); }
     | PROTOCOL EQ UNSIGNED { $$ = newExpression("PROTOCOL", $2, $3, 0); }
     | PROTOCOL EQ PROTO_NAME { $$ = (struct ast *) newProtocol($2, $3); }

--- a/unirecfilter/lib/scanner.l
+++ b/unirecfilter/lib/scanner.l
@@ -28,8 +28,9 @@ IPv6    ({h16}:){6}{ls32}|::({h16}:){5}{ls32}|({h16})?::({h16}:){4}{ls32}|(({h16
 IPv6MASK      [0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]
 
 DATETIME [0-9]{4}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{2}:[0-9]{2}:[0-9]{2}|[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}
-
-ARRAY \[[, .0-9a-zA-Z]+\]
+FLOAT       -?[0-9]+\.[0-9]+
+ARRAY_ELEM  -?[0-9]+|{IPv4}|{IPv6}|{DATETIME}|{FLOAT}
+ARRAY \[{ARRAY_ELEM}(," "*{ARRAY_ELEM})*\]
 
 %%
 
@@ -42,7 +43,7 @@ ARRAY \[[, .0-9a-zA-Z]+\]
 {DATETIME}                                               { yylval.string = copyString(yytext, yyleng); return DATETIME; }
 \"({DATETIME})\"                                         { yylval.string = cutString(yytext, yyleng); return DATETIME; }
 {ARRAY}                                                  { yylval.string = cutString(yytext, yyleng); return ARRAY; }
--?[0-9]+\.[0-9]+                                         { sscanf(yytext, "%lf", &yylval.floating); return FLOAT; }
+{FLOAT}                                                  { sscanf(yytext, "%lf", &yylval.floating); return FLOAT; }
 -[0-9]+                                                  { sscanf(yytext, "%" SCNi64, &yylval.number); return SIGNED; }
 [0-9]+                                                   { sscanf(yytext, "%" SCNi64, &yylval.number); return UNSIGNED; }
 {IPv4}("/"{IPv4MASK})?                                   { yylval.string = copyString(yytext, yyleng); if (strchr(yytext, '/') == NULL) { return IP;} else {return NET;}}

--- a/unirecfilter/lib/scanner.l
+++ b/unirecfilter/lib/scanner.l
@@ -29,9 +29,11 @@ IPv6MASK      [0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]
 
 DATETIME [0-9]{4}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{2}:[0-9]{2}:[0-9]{2}|[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}
 
+ARRAY \[[, .0-9a-zA-Z]+\]
+
 %%
 
-">"|"<"|"=<"|"<="|">="|"=>"                              { yylval.string = copyString(yytext, yyleng); return CMP; }
+">"|"<"|"=<"|"<="|">="|"=>"|"IN"|"in"                    { yylval.string = copyString(yytext, yyleng); return CMP; }
 "="|"=="|"!="|"<>"                                       { yylval.string = copyString(yytext, yyleng); return EQ; }
 "=~"|"~="                                                { yylval.string = copyString(yytext, yyleng); return REGEX; }
 "!"|"NOT"                                                { return NOT; }
@@ -39,6 +41,7 @@ DATETIME [0-9]{4}-[0-9]{1,2}-[0-9]{1,2}T[0-9]{2}:[0-9]{2}:[0-9]{2}|[0-9]{4}-[0-9
 "&&"|"AND"                                               { return AND; }
 {DATETIME}                                               { yylval.string = copyString(yytext, yyleng); return DATETIME; }
 \"({DATETIME})\"                                         { yylval.string = cutString(yytext, yyleng); return DATETIME; }
+{ARRAY}                                                  { yylval.string = cutString(yytext, yyleng); return ARRAY; }
 -?[0-9]+\.[0-9]+                                         { sscanf(yytext, "%lf", &yylval.floating); return FLOAT; }
 -[0-9]+                                                  { sscanf(yytext, "%" SCNi64, &yylval.number); return SIGNED; }
 [0-9]+                                                   { sscanf(yytext, "%" SCNi64, &yylval.number); return UNSIGNED; }

--- a/unirecfilter/lib/test_liburfilter.c
+++ b/unirecfilter/lib/test_liburfilter.c
@@ -1,0 +1,66 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+
+#include <unirec/unirec.h>
+
+#include "liburfilter.h"
+
+static void test_create_destroy(void **state)
+{
+   urfilter_t *urf = urfilter_create("", "testifc0");
+   assert_int_equal(urfilter_compile(urf), URFILTER_ERROR);
+   urfilter_destroy(urf);
+
+   urfilter_destroy(NULL);
+}
+
+static void test_checkipandport(void **state)
+{
+   urfilter_t *urf = urfilter_create("SRC_IP == \"10.0.0.1\" and DST_PORT==80", "testifc0");
+   assert_int_equal(urfilter_compile(urf), URFILTER_TRUE);
+   urfilter_destroy(urf);
+}
+
+static void test_array(void **state)
+{
+   urfilter_t *urf = urfilter_create("DST_PORT in [8443, 80, 8080, 443]", "testifc0");
+   assert_int_equal(urfilter_compile(urf), URFILTER_TRUE);
+   
+   ur_template_t *tmplt = ur_create_template("SRC_IP,DST_PORT", NULL);
+   void *rec = ur_create_record(tmplt, 0);
+   void *fv = ur_get_ptr_by_id(tmplt, rec, ur_get_id_by_name("DST_PORT"));
+   *((uint16_t *) fv) = 123;
+
+   int result;
+   result = urfilter_match(urf, tmplt, rec);
+   assert_int_equal(result, 0);
+
+   *((uint16_t *) fv) = 443;
+   result = urfilter_match(urf, tmplt, rec);
+   assert_int_equal(result, 1);
+
+   urfilter_destroy(urf);
+
+   ur_free_record(rec);
+   ur_free_template(tmplt);
+}
+
+int main(void)
+{
+   ur_define_field("SRC_IP", UR_TYPE_IP);
+   ur_define_field("DST_PORT", UR_TYPE_UINT16);
+
+   const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_create_destroy),
+      cmocka_unit_test(test_checkipandport),
+      cmocka_unit_test(test_array)
+   };
+
+   return cmocka_run_group_tests(tests, NULL, NULL);
+}
+

--- a/unirecfilter/lib/test_liburfilter.c
+++ b/unirecfilter/lib/test_liburfilter.c
@@ -30,7 +30,7 @@ static void test_array(void **state)
 {
    urfilter_t *urf = urfilter_create("DST_PORT in [8443, 80, 8080, 443]", "testifc0");
    assert_int_equal(urfilter_compile(urf), URFILTER_TRUE);
-   
+
    ur_template_t *tmplt = ur_create_template("SRC_IP,DST_PORT", NULL);
    void *rec = ur_create_record(tmplt, 0);
    void *fv = ur_get_ptr_by_id(tmplt, rec, ur_get_id_by_name("DST_PORT"));
@@ -50,17 +50,95 @@ static void test_array(void **state)
    ur_free_template(tmplt);
 }
 
+static void test_array_ip4(void **state)
+{
+   int result;
+   urfilter_t *urf = urfilter_create("SRC_IP in [10.0.0.1, 172.16.0.2, 192.168.0.1, 192.168.1.1]", "testifc0");
+   assert_int_equal(urfilter_compile(urf), URFILTER_TRUE);
+
+   ur_template_t *tmplt = ur_create_template("SRC_IP,DST_PORT", NULL);
+   void *rec = ur_create_record(tmplt, 0);
+   void *fv = ur_get_ptr_by_id(tmplt, rec, ur_get_id_by_name("SRC_IP"));
+   ip_from_str("172.16.0.1", fv);
+
+   result = urfilter_match(urf, tmplt, rec);
+   assert_int_equal(result, 0);
+
+   ip_from_str("10.0.0.1", fv);
+   result = urfilter_match(urf, tmplt, rec);
+   assert_int_equal(result, 1);
+
+   urfilter_destroy(urf);
+
+   ur_free_record(rec);
+   ur_free_template(tmplt);
+}
+
+static void test_array_double(void **state)
+{
+   int result;
+   urfilter_t *urf = urfilter_create("SCALE in [1.5, 2.7, 3.14]", "testifc0");
+   assert_int_equal(urfilter_compile(urf), URFILTER_TRUE);
+
+   ur_template_t *tmplt = ur_create_template("SRC_IP,DST_PORT,SCALE", NULL);
+   void *rec = ur_create_record(tmplt, 0);
+   double *fv = ur_get_ptr_by_id(tmplt, rec, ur_get_id_by_name("SCALE"));
+   *fv = 1.8;
+
+   result = urfilter_match(urf, tmplt, rec);
+   assert_int_equal(result, 0);
+
+   *fv = 3.14;
+   result = urfilter_match(urf, tmplt, rec);
+   assert_int_equal(result, 1);
+
+   urfilter_destroy(urf);
+
+   ur_free_record(rec);
+   ur_free_template(tmplt);
+}
+
+static void test_array_time(void **state)
+{
+   int result;
+   // TODO - segfault:
+   //urfilter_t *urf = urfilter_create("SCALE in [2020-04-09T01:02:21, 2020-04-09T01:02:23, 2020-04-09T01:02:22]", "testifc0");
+   //
+   urfilter_t *urf = urfilter_create("TIME in [2020-04-09T01:02:21, 2020-04-09T01:02:23, 2020-04-09T01:02:22]", "testifc0");
+   assert_int_equal(urfilter_compile(urf), URFILTER_TRUE);
+
+   ur_template_t *tmplt = ur_create_template("SRC_IP,DST_PORT,TIME", NULL);
+   void *rec = ur_create_record(tmplt, 0);
+   ur_time_t *fv = ur_get_ptr_by_id(tmplt, rec, ur_get_id_by_name("TIME"));
+   ur_time_from_string(fv, "2019-04-09T01:02:21");
+   result = urfilter_match(urf, tmplt, rec);
+   assert_int_equal(result, 0);
+
+   ur_time_from_string(fv, "2020-04-09T01:02:22");
+   result = urfilter_match(urf, tmplt, rec);
+   assert_int_equal(result, 1);
+
+   urfilter_destroy(urf);
+
+   ur_free_record(rec);
+   ur_free_template(tmplt);
+}
+
 int main(void)
 {
    ur_define_field("SRC_IP", UR_TYPE_IP);
    ur_define_field("DST_PORT", UR_TYPE_UINT16);
+   ur_define_field("SCALE", UR_TYPE_DOUBLE);
+   ur_define_field("TIME", UR_TYPE_TIME);
 
    const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_create_destroy),
       cmocka_unit_test(test_checkipandport),
-      cmocka_unit_test(test_array)
+      cmocka_unit_test(test_array),
+      cmocka_unit_test(test_array_ip4),
+      cmocka_unit_test(test_array_double),
+      cmocka_unit_test(test_array_time)
    };
-
    return cmocka_run_group_tests(tests, NULL, NULL);
 }
 


### PR DESCRIPTION
This is a draft of an extension of liburfilter to support optimized
filtering of integer values like this:

`DST_PORT in [1, 234, 123, 80, 443]`

The array (in brackets `[` and `]`)is parsed, sorted, and finnaly in
evalAST() searched using bsearch().

This should be faster than complicated filter like this:

`DST_PORT == 1 or DST_PORT == 234 or DST_PORT == 123 or DST_PORT == 80 or DST_PORT == 443`

Note: this patch also adds a basic test in cmocka. To run it,
libcmocka-devel (or equivalent) must be installed.

The patch should be improved:
* distinguish signed / unsigned numbers (right now everything is
  compared as uint64_t)
* add missing UniRec types like ipaddr, macaddr, time