### PR TITLE
Ipfixexport fix

### DIFF
--- a/flow_meter/httpplugin.cpp
+++ b/flow_meter/httpplugin.cpp
@@ -109,6 +109,13 @@ HTTPPlugin::HTTPPlugin(const options_t &module_options, vector<plugin_opt> plugi
    recPrealloc = NULL;
 }
 
+HTTPPlugin::~HTTPPlugin()
+{
+   if (recPrealloc == NULL) {
+      delete recPrealloc;
+   }
+}
+
 int HTTPPlugin::post_create(Flow &rec, const Packet &pkt)
 {
    if (pkt.src_port == 80) {

--- a/flow_meter/httpplugin.h
+++ b/flow_meter/httpplugin.h
@@ -169,6 +169,7 @@ class HTTPPlugin : public FlowCachePlugin
 public:
    HTTPPlugin(const options_t &module_options);
    HTTPPlugin(const options_t &module_options, vector<plugin_opt> plugin_options);
+   ~HTTPPlugin();
    int post_create(Flow &rec, const Packet &pkt);
    int pre_update(Flow &rec, Packet &pkt);
    void finish();

--- a/flow_meter/httpsplugin.cpp
+++ b/flow_meter/httpsplugin.cpp
@@ -62,6 +62,7 @@ HTTPSPlugin::HTTPSPlugin(const options_t &module_options)
 {
    print_stats = module_options.print_stats;
    parsed_sni = 0;
+   total = 0;
    flow_flush = false;
    ext_ptr = NULL;
 }
@@ -70,8 +71,15 @@ HTTPSPlugin::HTTPSPlugin(const options_t &module_options, vector<plugin_opt> plu
 {
    print_stats = module_options.print_stats;
    parsed_sni = 0;
+   total = 0;
    flow_flush = false;
    ext_ptr = NULL;
+}
+HTTPSPlugin::~HTTPSPlugin()
+{
+   if (ext_ptr != NULL) {
+      delete ext_ptr;
+   }
 }
 
 int HTTPSPlugin::post_create(Flow &rec, const Packet &pkt)

--- a/flow_meter/httpsplugin.h
+++ b/flow_meter/httpsplugin.h
@@ -138,6 +138,7 @@ class HTTPSPlugin : public FlowCachePlugin
 public:
    HTTPSPlugin(const options_t &module_options);
    HTTPSPlugin(const options_t &module_options, vector<plugin_opt> plugin_options);
+   ~HTTPSPlugin();
    int post_create(Flow &rec, const Packet &pkt);
    int pre_update(Flow &rec, Packet &pkt);
    void finish();

--- a/flow_meter/ipfixexporter.cpp
+++ b/flow_meter/ipfixexporter.cpp
@@ -203,7 +203,7 @@ int IPFIXExporter::export_flow(Flow &flow)
       tmplt = templateArray[basic_ifc_num * 2 + ipv6_tmplt];
 
       int length = fill_basic_flow(flow, tmplt);
-      if (length == -1) {
+      while (length == -1) {
          send_templates();
          send_data();
 
@@ -218,7 +218,7 @@ int IPFIXExporter::export_flow(Flow &flow)
             tmplt = templateArray[tmplt_num * 2 + ipv6_tmplt];
 
             int length_basic = fill_basic_flow(flow, tmplt);
-            if (length_basic == -1) {
+            while (length_basic == -1) {
                send_templates();
                send_data();
 
@@ -227,7 +227,7 @@ int IPFIXExporter::export_flow(Flow &flow)
 
             int length_ext = ext->fillIPFIX(tmplt->buffer + tmplt->bufferSize + length_basic,
                               TEMPLATE_BUFFER_SIZE - tmplt->bufferSize - length_basic);
-            if (length_ext == -1) {
+            while (length_ext == -1) {
                send_templates();
                send_data();
 


### PR DESCRIPTION
Fixed invalid sequence number computation when exporting IPFIX.
Fixed memory leaks and use of uninitialized values errors.