### PR TITLE
Pstat plugin IPFIX export fixed

### DIFF
--- a/flow_meter/Makefile.am
+++ b/flow_meter/Makefile.am
@@ -57,7 +57,8 @@ flow_meter_src=flow_meter.cpp \
 		conversion.h \
 		conversion.cpp \
 		pstatsplugin.h \
-		pstatsplugin.cpp
+		pstatsplugin.cpp \
+		byte-utils.h
 
 ipfixprobe_SOURCES=$(flow_meter_src)
 

--- a/flow_meter/byte-utils.h
+++ b/flow_meter/byte-utils.h
@@ -1,0 +1,58 @@
+/**
+ * \file ipfixexporter.cpp
+ * \brief Export flows in IPFIX format.
+ *    The following code was used https://dior.ics.muni.cz/~velan/flowmon-export-ipfix/
+ * \author Jiri Havranek <havraji6@fit.cvut.cz>
+ * \author Tomas Cejka <cejkat@cesnet.cz>
+ * \author Karel Hynek <hynekkar@fit.cvut.cz>
+ * \date 2020
+ */
+/*
+ * Copyright (C) 2012 Masaryk University, Institute of Computer Science
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * 3. Neither the name of the Masaryk University nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * This software is provided ``as is'', and any express or implied
+ * warranties, including, but not limited to, the implied warranties of
+ * merchantability and fitness for a particular purpose are disclaimed.
+ * In no event shall the company or contributors be liable for any
+ * direct, indirect, incidental, special, exemplary, or consequential
+ * damages (including, but not limited to, procurement of substitute
+ * goods or services; loss of use, data, or profits; or business
+ * interruption) however caused and on any theory of liability, whether
+ * in contract, strict liability, or tort (including negligence or
+ * otherwise) arising in any way out of the use of this software, even
+ * if advised of the possibility of such damage.
+*/
+#include <stdint.h>
+
+/**
+ * \brief Swaps byte order of 8 B value.
+ * @param value Value to swap
+ * @return Swapped value
+ */
+#if BYTEORDER == 4321 /* Big endian */
+static inline uint64_t swap_uint64(uint64_t value)
+{
+   return value;
+}
+#else
+static inline uint64_t swap_uint64(uint64_t value)
+{
+   value = ((value << 8) & 0xFF00FF00FF00FF00ULL ) | ((value >> 8) & 0x00FF00FF00FF00FFULL );
+   value = ((value << 16) & 0xFFFF0000FFFF0000ULL ) | ((value >> 16) & 0x0000FFFF0000FFFFULL );
+   return (value << 32) | (value >> 32);
+}
+#endif

--- a/flow_meter/ipfixexporter.cpp
+++ b/flow_meter/ipfixexporter.cpp
@@ -57,6 +57,7 @@
 #include "ipfixexporter.h"
 #include "flowifc.h"
 #include "ipfix-elements.h"
+#include "byte-utils.h"
 
 #define GCC_CHECK_PRAGMA ((__GNUC__ == 4 && 6 <= __GNUC_MINOR__) || 4 < __GNUC__)
 
@@ -994,25 +995,6 @@ int IPFIXExporter::reconnect()
 }
 
 /**
- * \brief Swaps byte order of 8 B value.
- * @param value Value to swap
- * @return Swapped value
- */
-#if BYTEORDER == 4321 /* Big endian */
-static inline uint64_t swap_uint64(uint64_t value)
-{
-   return value;
-}
-#else
-static inline uint64_t swap_uint64(uint64_t value)
-{
-   value = ((value << 8) & 0xFF00FF00FF00FF00ULL ) | ((value >> 8) & 0x00FF00FF00FF00FFULL );
-   value = ((value << 16) & 0xFFFF0000FFFF0000ULL ) | ((value >> 16) & 0x0000FFFF0000FFFFULL );
-   return (value << 32) | (value >> 32);
-}
-#endif
-
-/**
  * \brief Fill template buffer with packet fields.
  * @param pkt Packet
  * @param tmplt Template containing buffer
@@ -1106,4 +1088,3 @@ int IPFIXExporter::fill_basic_flow(Flow &flow, template_t *tmplt)
 
    return length;
 }
-

--- a/flow_meter/pstatsplugin.h
+++ b/flow_meter/pstatsplugin.h
@@ -52,6 +52,7 @@
 #include "flowcacheplugin.h"
 #include "packet.h"
 #include "flow_meter.h"
+#include "byte-utils.h"
 
 
 #ifndef PSTATS_MAXELEMCOUNT
@@ -59,24 +60,6 @@
 #endif
 
 using namespace std;
-
-#define IPFIX_TLS_RECORD_LENGTHS 44956
-#define IPFIX_TLS_RECORD_TIMES 44957
-
-/**
- * \brief Swaps byte order of 8 B value.
- * @param value Value to swap
- * @return Swapped value
- */
- static inline uint64_t htonll(uint64_t n)
- {
- #if __BYTE_ORDER == __BIG_ENDIAN
-     return n;
- #else
-     return (((uint64_t)htonl(n)) << 32) + htonl(n >> 32);
- #endif
- }
-
 
 static inline uint64_t tv2ts(timeval input)
 {
@@ -207,7 +190,7 @@ struct RecordExtPSTATS : RecordExt {
       hdr.hdrElementLength = sizeof(uint64_t);
       bufferPtr += FillBasicListBuffer(hdr, buffer + bufferPtr, size);
       for (int i = 0; i < pkt_count; i++) {
-         (*reinterpret_cast<uint64_t *>(buffer + bufferPtr)) = htonll(tv2ts(pkt_timestamps[i]));
+         (*reinterpret_cast<uint64_t *>(buffer + bufferPtr)) = swap_uint64(tv2ts(pkt_timestamps[i]));
          bufferPtr += sizeof(uint64_t);
 
       }

--- a/flow_meter/pstatsplugin.h
+++ b/flow_meter/pstatsplugin.h
@@ -80,7 +80,7 @@ using namespace std;
 
 static inline uint64_t tv2ts(timeval input)
 {
-  return static_cast<uint64_t>(input.tv_sec) * 1000 + (input.tv_sec / 1000);
+  return static_cast<uint64_t>(input.tv_sec) * 1000 + (input.tv_usec / 1000);
 }
 
 


### PR DESCRIPTION
The previous implementation used the wrong format of IPDIX datatype "dateTimeMilliseconds". This PR fixed the issue.