### PR TITLE
flow_meter: ndp: bugfix bad conversion of nanoseconds

### DIFF
--- a/flow_meter/pcapreader.cpp
+++ b/flow_meter/pcapreader.cpp
@@ -780,7 +780,7 @@ void packet_ndp_handler(Packet *pkt, const struct ndp_packet *ndp_packet, const 
 {
    struct timeval ts;
    ts.tv_sec = ndp_header->timestamp_sec;
-   ts.tv_usec = ndp_header->timestamp_nsec * 1000;
+   ts.tv_usec = ndp_header->timestamp_nsec / 1000;
 
    parse_packet(pkt, ts, ndp_packet->data, ndp_packet->data_length, ndp_packet->data_length);
 }


### PR DESCRIPTION
Bad conversion of nanoseconds from NDP caused malformed timestamps.