### PR TITLE
flow_meter: MAINTENANCE deduplicate list of supported plugins

### DIFF
--- a/flow_meter/create_plugin.sh
+++ b/flow_meter/create_plugin.sh
@@ -206,7 +206,7 @@ print_todo() {
    echo "1) Add '${PLUGIN}plugin.h' and '${PLUGIN}plugin.cpp' files to flow_meter_src variable in Makefile.am"
    echo "2) Add '${PLUGIN}' entry to the extTypeEnum in flowifc.h"
    echo "3) Add '#include <${PLUGIN}plugin.h>' line to flow_meter.cpp"
-   echo "4) Add ${PLUGIN} to list of supported plugins for -p param in flow_meter.cpp (also update README.md)"
+   echo "4) Add ${PLUGIN} to list of supported plugins for -p param in flow_meter.cpp - SUPPORTED_PLUGINS_LIST macro (also update README.md)"
    echo "5) Add plugin support in parse_plugin_settings function in flow_meter.cpp"
    echo "6.1) Add unirec fields to the UR_FIELDS and ${PLUGIN_UPPER}_UNIREC_TEMPLATE macro in ${PLUGIN}plugin.cpp"
    echo "6.2) Add IPFIX template macro 'IPFIX_${PLUGIN_UPPER}_TEMPLATE' to ipfix-elements.h"

--- a/flow_meter/flow_meter.cpp
+++ b/flow_meter/flow_meter.cpp
@@ -85,11 +85,13 @@ static int stop = 0;
 #define MODULE_BASIC_INFO(BASIC) \
   BASIC("flow_meter", "Convert packets from PCAP file or network interface into biflow records.", 0, -1)
 
+#define SUPPORTED_PLUGINS_LIST "http,https,dns,sip,ntp,smtp,basic,arp,passivedns,pstats,ssdp,dnssd"
+
 // TODO: remove parameters when using ndp
 #define MODULE_PARAMS(PARAM) \
   PARAM('p', "plugins", "Activate specified parsing plugins. Output interface for each plugin correspond the order which you specify items in -i and -p param. "\
   "For example: \'-i u:a,u:b,u:c -p http,basic,dns\' http traffic will be send to interface u:a, basic flow to u:b etc. If you don't specify -p parameter, flow meter"\
-  " will require one output interface for basic flow by default. Format: plugin_name[,...] Supported plugins: http,https,dns,sip,ntp,smtp,basic,arp,passivedns,pstats,ssdp,dnssd"\
+  " will require one output interface for basic flow by default. Format: plugin_name[,...] Supported plugins: " SUPPORTED_PLUGINS_LIST \
   " Some plugins have features activated with additional parameters. Format: plugin_name[:plugin_param=value[:...]][,...] If plugin does not support parameters, any parameters given will be ignored."\
   " Supported plugin parameters are listed in README", required_argument, "string")\
   PARAM('c', "count", "Quit after number of packets are captured.", required_argument, "uint32")\
@@ -316,7 +318,7 @@ int main(int argc, char *argv[])
       puts("ipfixprobe version " VERSION);
       puts("ipfixprobe is a simplified flow exporter (flow_meter) without libtrap&UniRec support.");
       puts("");
-      puts("Usage: ipfixprobe [-I interface] -x host:port [-u] [-p http,https,dns,sip,ntp,smtp,basic,arp,passivedns] [-r file]");
+      puts("Usage: ipfixprobe [-I interface] -x host:port [-u] [-p " SUPPORTED_PLUGINS_LIST "] [-r file]");
       puts("");
 #endif
    } else if (verbose >= 0) {


### PR DESCRIPTION
ipfixprobe and flow_meter had separated lists of supported plugins. This PR defines a single macro that is contained in both help strings.