### PR TITLE
flow_meter: ssdp plugin patch

### DIFF
--- a/flow_meter/ssdpplugin.cpp
+++ b/flow_meter/ssdpplugin.cpp
@@ -130,39 +130,31 @@ void SSDPPlugin::finish()
 /**
  * \brief Parses port from location header message string.
  * 
- * \param [in, out] data Pointer to pointer to SSDP data.
+ * \param [in, out] data Pointer to SSDP data.
  * \param [in] ip_version IP version of the Location url being parsed.
- * \return Parsed port number on success, -1 otherwise.
+ * \return Parsed port number on success, 0 otherwise.
  */
-int SSDPPlugin::parse_loc_port(char **data, uint8_t ip_version){
-   int port;
+uint16_t SSDPPlugin::parse_loc_port(char *data, uint8_t ip_version)
+{
+   uint16_t port;
    char *end_ptr = NULL;
-   if(ip_version == 6){
-      while(**data){
-         if(*(*data)++ == ']'){
-            (*data)++;
-            break;
-         }
-      }
+
+   if (ip_version == 6) {
+      data = strchr(data, ']');
+   } else {
+      data = strchr(data, '.');
    }
-   else {
-      while (**data){
-         if(*(*data)++ == '.'){
-            break;
-         }
-      }
-      while(**data){
-         if(*(*data)++ == ':'){
-            break;     
-         }
-      }
+   data = strchr(data, ':');
+
+   if (data) {
+      data++;
    }
-   port = strtol(*data, &end_ptr, 0);
-   if(*data != end_ptr){
+
+   port = strtol(data, &end_ptr, 0);
+   if (data != end_ptr) {
       return port;
-   }
-   else {
-      return -1;
+   } else {
+      return 0;
    }
 }
 
@@ -217,7 +209,7 @@ void SSDPPlugin::parse_headers(char *data, header_parser_conf conf){
                      break;
                   case LOCATION:
                   {
-                     uint16_t port = parse_loc_port(&old_ptr, conf.ip_version);
+                     uint16_t port = parse_loc_port(old_ptr, conf.ip_version);
                      if (port > 0){
                         SSDP_DEBUG_MSG("%d <- %d\n", conf.ext->port, port);
                         conf.ext->port = port;

--- a/flow_meter/ssdpplugin.cpp
+++ b/flow_meter/ssdpplugin.cpp
@@ -80,7 +80,7 @@ enum header_types {
    NONE
 };
 
-const char *headers[]= {
+const char *headers[] = {
    "location",
    "nt",
    "st",
@@ -108,11 +108,11 @@ SSDPPlugin::SSDPPlugin(const options_t &module_options, vector<plugin_opt> plugi
 
 int SSDPPlugin::post_create(Flow &rec, const Packet &pkt)
 {
-   if (pkt.dst_port == 1900){
+   if (pkt.dst_port == 1900) {
       record = new RecordExtSSDP();
       rec.addExtension(record);
       record = NULL;
-      
+
       parse_ssdp_message(rec, pkt);
    }
    return 0;
@@ -120,7 +120,7 @@ int SSDPPlugin::post_create(Flow &rec, const Packet &pkt)
 
 int SSDPPlugin::pre_update(Flow &rec, Packet &pkt)
 {
-   if (pkt.dst_port == 1900){
+   if (pkt.dst_port == 1900) {
       parse_ssdp_message(rec, pkt);
    }
    return 0;
@@ -175,11 +175,11 @@ uint16_t SSDPPlugin::parse_loc_port(char *data, uint8_t ip_version)
  * \param [in] len Lenght of the desired header.
  * \return True if the header is found, otherwise false.
  */
-bool SSDPPlugin::get_header_val(char **data, const char* header, const int len){
-   if(strncasecmp(*data, header, len) == 0 &&
-      (*data)[len] == ':'){
+bool SSDPPlugin::get_header_val(char **data, const char *header, const int len)
+{
+   if (strncasecmp(*data, header, len) == 0 && (*data)[len] == ':') {
       (*data) += len + 1;
-      while(isspace(**data)){
+      while (isspace(**data)) {
          (*data)++;
       };
       return true;
@@ -193,48 +193,50 @@ bool SSDPPlugin::get_header_val(char **data, const char* header, const int len){
  * \param [in] data Pointer to pointer to SSDP data.
  * \param [in] conf Struct containing parser configuration.
  */
-void SSDPPlugin::parse_headers(char *data, header_parser_conf conf){
+void SSDPPlugin::parse_headers(char *data, header_parser_conf conf)
+{
    char *ptr = data;
    char *old_ptr = ptr;
-   while (*ptr != '\0'){
-      if (*ptr == '\n' && *(ptr-1) == '\r') {
-         *(ptr-1) = '\0';
-         for(unsigned j = 0, i = 0; j < conf.select_cnt; j++){
+
+   while (*ptr != '\0') {
+      if (*ptr == '\n' && *(ptr - 1) == '\r') {
+         *(ptr - 1) = '\0';
+         for (unsigned j = 0, i = 0; j < conf.select_cnt; j++) {
             i = conf.select[j];
-            if (get_header_val(&old_ptr, conf.headers[i], strlen(conf.headers[i]))){
-               switch ((header_types) i)
-               {
-                  case ST:
-                     if(get_header_val(&old_ptr, "urn", strlen("urn"))){
-                        SSDP_DEBUG_MSG("%s\n", old_ptr);
-                        append_value(conf.ext->st, SSDP_URN_LEN, old_ptr);
-                     }
-                     break;
-                  case NT:
-                     if(get_header_val(&old_ptr, "urn", strlen("urn"))){
-                        SSDP_DEBUG_MSG("%s\n", old_ptr);
-                        append_value(conf.ext->nt, SSDP_URN_LEN, old_ptr);
-                     }
-                     break;
-                  case LOCATION:
+            if (get_header_val(&old_ptr, conf.headers[i], strlen(conf.headers[i]))) {
+               switch ((header_types) i) {
+               case ST:
+                  if (get_header_val(&old_ptr, "urn", strlen("urn"))) {
+                     SSDP_DEBUG_MSG("%s\n", old_ptr);
+                     append_value(conf.ext->st, SSDP_URN_LEN, old_ptr);
+                  }
+                  break;
+               case NT:
+                  if (get_header_val(&old_ptr, "urn", strlen("urn"))) {
+                     SSDP_DEBUG_MSG("%s\n", old_ptr);
+                     append_value(conf.ext->nt, SSDP_URN_LEN, old_ptr);
+                  }
+                  break;
+               case LOCATION:
                   {
                      uint16_t port = parse_loc_port(old_ptr, conf.ip_version);
-                     if (port > 0){
+
+                     if (port > 0) {
                         SSDP_DEBUG_MSG("%d <- %d\n", conf.ext->port, port);
                         conf.ext->port = port;
                      }
                      break;
                   }
-                  case USER_AGENT:
-                     SSDP_DEBUG_MSG("%s\n", old_ptr);
-                     append_value(conf.ext->user_agent, SSDP_USER_AGENT_LEN, old_ptr);
-                     break;
-                  case SERVER:
-                     SSDP_DEBUG_MSG("%s\n", old_ptr);
-                     append_value(conf.ext->server, SSDP_SERVER_LEN, old_ptr);
-                     break;
-                  default:
-                     break;         
+               case USER_AGENT:
+                  SSDP_DEBUG_MSG("%s\n", old_ptr);
+                  append_value(conf.ext->user_agent, SSDP_USER_AGENT_LEN, old_ptr);
+                  break;
+               case SERVER:
+                  SSDP_DEBUG_MSG("%s\n", old_ptr);
+                  append_value(conf.ext->server, SSDP_SERVER_LEN, old_ptr);
+                  break;
+               default:
+                  break;
                }
                break;
             }
@@ -255,9 +257,10 @@ void SSDPPlugin::parse_headers(char *data, header_parser_conf conf){
  * \param [in] entry_max Maximum length if the entry.
  * \param [in] value String containing the new entry.
  */
-void SSDPPlugin::append_value(char *curr_entry, unsigned entry_max, char *value){
-   if(strlen(curr_entry) + strlen(value) + 1 < entry_max){
-      if(strstr(curr_entry, value) == NULL){
+void SSDPPlugin::append_value(char *curr_entry, unsigned entry_max, char *value)
+{
+   if (strlen(curr_entry) + strlen(value) + 1 < entry_max) {
+      if (strstr(curr_entry, value) == NULL) {
          SSDP_DEBUG_MSG("New entry\n");
          strcat(curr_entry, value);
          strcat(curr_entry, ";");
@@ -273,28 +276,29 @@ void SSDPPlugin::append_value(char *curr_entry, unsigned entry_max, char *value)
  * \param [in, out] rec Flow record containing basic flow data.
  * \param [in] pkt Packet struct containing packet data.
  */
-void SSDPPlugin::parse_ssdp_message(Flow &rec, const Packet &pkt){
+void SSDPPlugin::parse_ssdp_message(Flow &rec, const Packet &pkt)
+{
    header_parser_conf parse_conf = {
       headers,
       rec.ip_version,
       dynamic_cast<RecordExtSSDP *>(rec.getExtension(ssdp))
    };
-   char* data = (char*) pkt.payload;
+   char *data = (char *) pkt.payload;
+
    total++;
-   if(data[0] == 'N'){
+   if (data[0] == 'N') {
       notifies++;
       SSDP_DEBUG_MSG("Notify #%d\n", notifies);
       int notify_headers[] = { NT, LOCATION, SERVER };
       parse_conf.select = notify_headers;
-      parse_conf.select_cnt = sizeof(notify_headers)/sizeof(notify_headers[0]);
+      parse_conf.select_cnt = sizeof(notify_headers) / sizeof(notify_headers[0]);
       parse_headers(data, parse_conf);
-   }
-   else if (data[0] == 'M'){
+   } else if (data[0] == 'M') {
       searches++;
       SSDP_DEBUG_MSG("M-search #%d\n", searches);
       int search_headers[] = { ST, USER_AGENT };
       parse_conf.select = search_headers;
-      parse_conf.select_cnt = sizeof(search_headers)/sizeof(search_headers[0]);
+      parse_conf.select_cnt = sizeof(search_headers) / sizeof(search_headers[0]);
       parse_headers(data, parse_conf);
    }
    SSDP_DEBUG_MSG("\n");

--- a/flow_meter/ssdpplugin.cpp
+++ b/flow_meter/ssdpplugin.cpp
@@ -92,12 +92,18 @@ SSDPPlugin::SSDPPlugin(const options_t &module_options)
 {
    record = NULL;
    print_stats = module_options.print_stats;
+   notifies = 0;
+   searches = 0;
+   total = 0;
 }
 
 SSDPPlugin::SSDPPlugin(const options_t &module_options, vector<plugin_opt> plugin_options) : FlowCachePlugin(plugin_options)
 {
    record = NULL;
    print_stats = module_options.print_stats;
+   notifies = 0;
+   searches = 0;
+   total = 0;
 }
 
 int SSDPPlugin::post_create(Flow &rec, const Packet &pkt)
@@ -124,6 +130,9 @@ void SSDPPlugin::finish()
 {
    if (print_stats) {
       cout << "SSDP plugin stats:" << endl;
+      cout << "   Parsed SSDP M-Searches: " << searches << endl;
+      cout << "   Parsed SSDP Notifies: " << notifies << endl;
+      cout << "   Total SSDP packets processed: " << total << endl;
    }
 }
 
@@ -271,15 +280,18 @@ void SSDPPlugin::parse_ssdp_message(Flow &rec, const Packet &pkt){
       dynamic_cast<RecordExtSSDP *>(rec.getExtension(ssdp))
    };
    char* data = (char*) pkt.payload;
+   total++;
    if(data[0] == 'N'){
-      SSDP_DEBUG_MSG("Notify\n");
+      notifies++;
+      SSDP_DEBUG_MSG("Notify #%d\n", notifies);
       int notify_headers[] = { NT, LOCATION, SERVER };
       parse_conf.select = notify_headers;
       parse_conf.select_cnt = sizeof(notify_headers)/sizeof(notify_headers[0]);
       parse_headers(data, parse_conf);
    }
    else if (data[0] == 'M'){
-      SSDP_DEBUG_MSG("M-search\n");
+      searches++;
+      SSDP_DEBUG_MSG("M-search #%d\n", searches);
       int search_headers[] = { ST, USER_AGENT };
       parse_conf.select = search_headers;
       parse_conf.select_cnt = sizeof(search_headers)/sizeof(search_headers[0]);

--- a/flow_meter/ssdpplugin.cpp
+++ b/flow_meter/ssdpplugin.cpp
@@ -197,8 +197,8 @@ void SSDPPlugin::parse_headers(char *data, header_parser_conf conf){
    char *ptr = data;
    char *old_ptr = ptr;
    while (*ptr != '\0'){
-      if(*ptr == '\n'){
-         *ptr = '\0';
+      if (*ptr == '\n' && *(ptr-1) == '\r') {
+         *(ptr-1) = '\0';
          for(unsigned j = 0, i = 0; j < conf.select_cnt; j++){
             i = conf.select[j];
             if (get_header_val(&old_ptr, conf.headers[i], strlen(conf.headers[i]))){

--- a/flow_meter/ssdpplugin.h
+++ b/flow_meter/ssdpplugin.h
@@ -159,6 +159,9 @@ private:
    void append_value(char *curr_entry, unsigned entry_max, char *value);
 
    bool print_stats;       /**< Indicator whether to print stats when flow cache is finishing or not. */
+   uint32_t notifies;      /**< Total number of parsed SSDP notifies. */
+   uint32_t searches;      /**< Total number of parsed SSDP m-searches. */
+   uint32_t total;         /**< Total number of parsed SSDP packets. */
    RecordExtSSDP *record;  /**< Pointer to allocated record extension */
 };
 

--- a/flow_meter/ssdpplugin.h
+++ b/flow_meter/ssdpplugin.h
@@ -100,13 +100,19 @@ struct RecordExtSSDP : RecordExt {
       int st_len = strlen(st);
       int user_agent_len = strlen(user_agent);
 
-      if (length + nt_len + server_len + st_len + user_agent_len + 4 > size){
+      if (length + nt_len + server_len + st_len + user_agent_len + 8 > size){
          return -1;
       }
 
       *(uint16_t *) (buffer) = ntohs(port);
 
-      buffer[length++] = nt_len;
+      if (nt_len >= 255) {
+         buffer[length++] = 255;
+         *(uint16_t *)(buffer + length) = ntohs(nt_len);
+         length += sizeof(uint16_t);
+      } else {
+         buffer[length++] = nt_len;
+      }
       memcpy(buffer + length, nt, nt_len);
       length += nt_len;
 
@@ -114,7 +120,13 @@ struct RecordExtSSDP : RecordExt {
       memcpy(buffer + length, server, server_len);
       length += server_len;
 
-      buffer[length++] = st_len;
+      if (st_len >= 255) {
+         buffer[length++] = 255;
+         *(uint16_t *)(buffer + length) = ntohs(st_len);
+         length += sizeof(uint16_t);
+      } else {
+         buffer[length++] = st_len;
+      }
       memcpy(buffer + length, st, st_len);
       length += st_len;
 

--- a/flow_meter/ssdpplugin.h
+++ b/flow_meter/ssdpplugin.h
@@ -94,13 +94,13 @@ struct RecordExtSSDP : RecordExt {
    virtual int fillIPFIX(uint8_t *buffer, int size)
    {
       int length = 2;
-      
+
       int nt_len = strlen(nt);
       int server_len = strlen(server);
       int st_len = strlen(st);
       int user_agent_len = strlen(user_agent);
 
-      if (length + nt_len + server_len + st_len + user_agent_len + 8 > size){
+      if (length + nt_len + server_len + st_len + user_agent_len + 8 > size) {
          return -1;
       }
 
@@ -165,7 +165,7 @@ public:
 
 private:
    uint16_t parse_loc_port(char *data, uint8_t ip_version);
-   bool get_header_val(char **data, const char* header, const int len);
+   bool get_header_val(char **data, const char *header, const int len);
    void parse_headers(char *data, header_parser_conf conf);
    void parse_ssdp_message(Flow &rec, const Packet &pkt);
    void append_value(char *curr_entry, unsigned entry_max, char *value);
@@ -178,4 +178,3 @@ private:
 };
 
 #endif
-

--- a/flow_meter/ssdpplugin.h
+++ b/flow_meter/ssdpplugin.h
@@ -152,7 +152,7 @@ public:
    } ;
 
 private:
-   int parse_loc_port(char **data, uint8_t ip_version);
+   uint16_t parse_loc_port(char *data, uint8_t ip_version);
    bool get_header_val(char **data, const char* header, const int len);
    void parse_headers(char *data, header_parser_conf conf);
    void parse_ssdp_message(Flow &rec, const Packet &pkt);


### PR DESCRIPTION
Bugfixes:
- Misinterpreted return value -1 as unsigned 65535 when parsing of location port failed - fixed in `parse_loc_port()` rework.
- SSDP_NT and SSDP_ST fields could be longer then 255 characters, but the ipfix export didn't properly account for this. -fixed
- The newline sequence used in SSDP `\r\n` was not being entirely removed. - fixed

Additions:
- SSDP plugin now has stats.

Codestyle: whitespace changes were made to suit the codestyle.