### PR TITLE
aggregator: "first non-empty" feature

### DIFF
--- a/aggregator/agg_functions.cpp
+++ b/aggregator/agg_functions.cpp
@@ -87,3 +87,30 @@ void last_variable(const void *src, void *dst)
    var_params *params = (var_params*)dst;
    ur_set_var(OutputTemplate::out_tmplt, params->dst, params->field_id, src, params->var_len);
 }
+
+
+/* ================================================================= */
+/* ================== First Non-Empty function ===================== */
+/* ================================================================= */
+void first_nonempty_var(const void *src, void *dst)
+{
+   var_params *params = (var_params*) dst;
+   if (ur_get_var_len(OutputTemplate::out_tmplt, params->dst, params->field_id) == 0) {
+      ur_set_var(OutputTemplate::out_tmplt, params->dst, params->field_id, src, params->var_len);
+   }
+}
+
+/* ================================================================= */
+/* ======================= Max function =========================== */
+/* ================================================================= */
+void first_nonempty_ip(const void *src, void *dst)
+{
+   // ret is positive number (>0) if addr1 > addr2
+   int ret = ip_is_null((const ip_addr_t *) dst);
+
+   if (ret == 0) {
+      *((ip_addr_t *)dst) = *((ip_addr_t *)src);
+   }
+   // or use memcpy(&dst, src, 16);
+}
+

--- a/aggregator/agg_functions.cpp
+++ b/aggregator/agg_functions.cpp
@@ -94,23 +94,24 @@ void last_variable(const void *src, void *dst)
 /* ================================================================= */
 void first_nonempty_var(const void *src, void *dst)
 {
-   var_params *params = (var_params*) dst;
+   var_params *params = (var_params *) dst;
+
    if (ur_get_var_len(OutputTemplate::out_tmplt, params->dst, params->field_id) == 0) {
       ur_set_var(OutputTemplate::out_tmplt, params->dst, params->field_id, src, params->var_len);
    }
 }
 
 /* ================================================================= */
-/* ======================= Max function =========================== */
+/* ============ First Non-Empty/Non-Zero IP address ================ */
 /* ================================================================= */
 void first_nonempty_ip(const void *src, void *dst)
 {
-   // ret is positive number (>0) if addr1 > addr2
+   // check if currently stored IP is null
    int ret = ip_is_null((const ip_addr_t *) dst);
 
-   if (ret == 0) {
-      *((ip_addr_t *)dst) = *((ip_addr_t *)src);
+   if (ret != 0 && ip_is_null((const ip_addr_t *) src) == 0) {
+      // replace null IP with the current non-null one
+      *((ip_addr_t *) dst) = *((ip_addr_t *) src);
    }
-   // or use memcpy(&dst, src, 16);
 }
 

--- a/aggregator/agg_functions.h
+++ b/aggregator/agg_functions.h
@@ -2,10 +2,11 @@
  * \file agg_functions.h
  * \brief Aggregation functions available for use in module.
  * \author Michal Slabihoudek <slabimic@fit.cvut.cz>
- * \date 2018
+ * \author Tomas Cejka <cejkat@cesnet.cz>
+ * \date 2018-2020
  */
 /*
- * Copyright (C) 2018 CESNET
+ * Copyright (C) 2018-2020 CESNET
  *
  * LICENSE TERMS
  *
@@ -151,7 +152,7 @@ void first_nonempty(const void *src, void *dst)
 }
 
 /**
- * Update currently stored value of dst pointer with one from src pointer of given type T.
+ * Update currently stored ip_addr_t value of dst pointer with one from src pointer
  * @tparam T template type variable.
  * @param [in] src pointer to source of new data.
  * @param [in,out] dst pointer to already stored data which will be updated (modified).
@@ -159,15 +160,15 @@ void first_nonempty(const void *src, void *dst)
 void first_nonempty_ip(const void *src, void *dst);
 
 /**
- * Update currently stored value of dst pointer with one from src pointer of given type T.
+ * Update currently stored variable-length field value of dst pointer (stored in var_params) with one from the src pointer
  * @tparam T template type variable.
  * @param [in] src pointer to source of new data.
- * @param [in,out] dst pointer to already stored data which will be updated (modified).
+ * @param [in,out] dst pointer to var_params instance with information about destination.
  */
 void first_nonempty_var(const void *src, void *dst);
 
 /**
- * Update currently stored value of dst pointer with one from src pointer of given type T.
+ * Update currently stored value of the fixed-length field in src pointer with the value in dst pointer of given type T.
  * @tparam T template type variable.
  * @param [in] src pointer to source of new data.
  * @param [in,out] dst pointer to already stored data which will be updated (modified).

--- a/aggregator/agg_functions.h
+++ b/aggregator/agg_functions.h
@@ -143,6 +143,36 @@ void nope(const void *src, void *dst); // Also min, because first value set usin
  * @param [in,out] dst pointer to already stored data which will be updated (modified).
  */
 template <typename T>
+void first_nonempty(const void *src, void *dst)
+{
+   if (*((T*) dst) == 0) {
+      *((T*) dst) = *((T*) src);
+   }
+}
+
+/**
+ * Update currently stored value of dst pointer with one from src pointer of given type T.
+ * @tparam T template type variable.
+ * @param [in] src pointer to source of new data.
+ * @param [in,out] dst pointer to already stored data which will be updated (modified).
+ */
+void first_nonempty_ip(const void *src, void *dst);
+
+/**
+ * Update currently stored value of dst pointer with one from src pointer of given type T.
+ * @tparam T template type variable.
+ * @param [in] src pointer to source of new data.
+ * @param [in,out] dst pointer to already stored data which will be updated (modified).
+ */
+void first_nonempty_var(const void *src, void *dst);
+
+/**
+ * Update currently stored value of dst pointer with one from src pointer of given type T.
+ * @tparam T template type variable.
+ * @param [in] src pointer to source of new data.
+ * @param [in,out] dst pointer to already stored data which will be updated (modified).
+ */
+template <typename T>
 void last(const void *src, void *dst)
 {
    *((T*)dst) = *((T*)src);

--- a/aggregator/aggregator.cpp
+++ b/aggregator/aggregator.cpp
@@ -128,6 +128,7 @@ UR_FIELDS (
   PARAM('m', "min", "Keep minimal value of UniRec field identified by given name.", required_argument, "URFIELD") \
   PARAM('M', "max", "Keep maximal value of UniRec field identified by given name.", required_argument, "URFIELD") \
   PARAM('f', "first", "Keep first value of UniRec field identified by given name.", required_argument, "URFIELD") \
+  PARAM('F', "firstne", "Keep first Non-Empty value of UniRec field identified by given name.", required_argument, "URFIELD") \
   PARAM('l', "last", "Keep first value of UniRec field identified by given name.", required_argument, "URFIELD") \
   PARAM('o', "or", "Make bitwise OR of UniRec field identified by given name.", required_argument, "URFIELD") \
   PARAM('n', "and", "Make bitwise AND of UniRec field identified by given name.", required_argument, "URFIELD")
@@ -518,6 +519,9 @@ int main(int argc, char **argv)
       case 'f':
          config.add_member(FIRST, optarg);
          break;
+      case 'F':
+         config.add_member(FIRST_NONEMPTY, optarg);
+         break;
       case 'l':
          config.add_member(LAST, optarg);
          break;
@@ -568,7 +572,8 @@ int main(int argc, char **argv)
 
       // Check for end-of-stream message, close only when signal caught
       if (in_rec_size <= 1) {
-         continue;
+         stop = 1;
+         break;
       }
 
       // Change of UniRec input template -> sanity check and templates creation

--- a/aggregator/aggregator.cpp
+++ b/aggregator/aggregator.cpp
@@ -271,7 +271,7 @@ void process_agg_functions(ur_template_t *in_tmplt, const void *src_rec, ur_temp
    void *ptr_src;
    // Process all registered fields with their agg function
    for (int i = 0; i < OutputTemplate::used_fields; i++) {
-      if (ur_is_fixlen(i)) {
+      if (ur_is_fixlen(OutputTemplate::indexes_to_record[i])) {
          ptr_dst = ur_get_ptr_by_id(out_tmplt, dst_rec, OutputTemplate::indexes_to_record[i]);
          ptr_src = ur_get_ptr_by_id(in_tmplt, src_rec, OutputTemplate::indexes_to_record[i]);
          OutputTemplate::process[i](ptr_src, ptr_dst);

--- a/aggregator/aggregator.cpp
+++ b/aggregator/aggregator.cpp
@@ -271,15 +271,16 @@ void process_agg_functions(ur_template_t *in_tmplt, const void *src_rec, ur_temp
    void *ptr_src;
    // Process all registered fields with their agg function
    for (int i = 0; i < OutputTemplate::used_fields; i++) {
-      if (ur_is_fixlen(OutputTemplate::indexes_to_record[i])) {
-         ptr_dst = ur_get_ptr_by_id(out_tmplt, dst_rec, OutputTemplate::indexes_to_record[i]);
-         ptr_src = ur_get_ptr_by_id(in_tmplt, src_rec, OutputTemplate::indexes_to_record[i]);
+      int field_id = OutputTemplate::indexes_to_record[i];
+      if (ur_is_fixlen(field_id)) {
+         ptr_dst = ur_get_ptr_by_id(out_tmplt, dst_rec, field_id);
+         ptr_src = ur_get_ptr_by_id(in_tmplt, src_rec, field_id);
          OutputTemplate::process[i](ptr_src, ptr_dst);
       }
       else {
-         var_params params = {dst_rec, i, ur_get_var_len(in_tmplt, src_rec, OutputTemplate::indexes_to_record[i])};
-         ptr_src = ur_get_ptr_by_id(in_tmplt, src_rec, OutputTemplate::indexes_to_record[i]);
-         OutputTemplate::process[i](ptr_src, (void*)&params);
+         var_params params = {dst_rec, field_id, ur_get_var_len(in_tmplt, src_rec, field_id)};
+         ptr_src = ur_get_ptr_by_id(in_tmplt, src_rec, field_id);
+         OutputTemplate::process[i](ptr_src, (void *) &params);
       }
    }
 }

--- a/aggregator/configuration.cpp
+++ b/aggregator/configuration.cpp
@@ -2,10 +2,11 @@
  * \file configuration.cpp
  * \brief Module running properties configuration.
  * \author Michal Slabihoudek <slabimic@fit.cvut.cz>
- * \date 2018
+ * \author Tomas Cejka <cejkat@cesnet.cz>
+ * \date 2018-2020
  */
 /*
- * Copyright (C) 2018 CESNET
+ * Copyright (C) 2018-2020 CESNET
  *
  * LICENSE TERMS
  *
@@ -129,361 +130,368 @@ agg_func Config::get_function_ptr(int index, ur_field_type_t field_type)
    }
 
    switch (functions[index]) {
-      case SUM:
-         switch (field_type) {
-            case UR_TYPE_INT8:
-               out = &sum<int8_t>;
-               break;
-            case UR_TYPE_INT16:
-               out = &sum<int16_t>;
-               break;
-            case UR_TYPE_INT32:
-               out = &sum<int32_t>;
-               break;
-            case UR_TYPE_INT64:
-               out = &sum<int64_t>;
-               break;
-            case UR_TYPE_UINT8:
-               out = &sum<uint8_t>;
-               break;
-            case UR_TYPE_UINT16:
-               out = &sum<uint16_t>;
-               break;
-            case UR_TYPE_UINT32:
-               out = &sum<uint32_t>;
-               break;
-            case UR_TYPE_UINT64:
-               out = &sum<uint64_t>;
-               break;
-            case UR_TYPE_FLOAT:
-               out = &sum<float>;
-               break;
-            case UR_TYPE_DOUBLE:
-               out = &sum<double>;
-               break;
-            default:
-               fprintf(stderr, "Only int, uint, float and double can use sum function, first assigned instead.\n");
-               out = &nope;
-         }
+   case SUM:
+      switch (field_type) {
+      case UR_TYPE_INT8:
+         out = &sum<int8_t>;
          break;
-      case AVG:
-         switch (field_type) {
-            case UR_TYPE_INT8:
-               out = &avg<int8_t>;
-               break;
-            case UR_TYPE_INT16:
-               out = &avg<int16_t>;
-               break;
-            case UR_TYPE_INT32:
-               out = &avg<int32_t>;
-               break;
-            case UR_TYPE_INT64:
-               out = &avg<int64_t>;
-               break;
-            case UR_TYPE_UINT8:
-               out = &avg<uint8_t>;
-               break;
-            case UR_TYPE_UINT16:
-               out = &avg<uint16_t>;
-               break;
-            case UR_TYPE_UINT32:
-               out = &avg<uint32_t>;
-               break;
-            case UR_TYPE_UINT64:
-               out = &avg<uint64_t>;
-               break;
-            case UR_TYPE_FLOAT:
-               out = &avg<float>;
-               break;
-            case UR_TYPE_DOUBLE:
-               out = &avg<double>;
-               break;
-            default:
-               fprintf(stderr, "Only int, uint, float and double can use avg function, first assigned instead.\n");
-               out = &nope;
-         }
+      case UR_TYPE_INT16:
+         out = &sum<int16_t>;
          break;
-      case MIN:
-         switch (field_type) {
-            case UR_TYPE_INT8:
-               out = &min<int8_t>;
-               break;
-            case UR_TYPE_INT16:
-               out = &min<int16_t>;
-               break;
-            case UR_TYPE_INT32:
-               out = &min<int32_t>;
-               break;
-            case UR_TYPE_INT64:
-               out = &min<int64_t>;
-               break;
-            case UR_TYPE_UINT8:
-               out = &min<uint8_t>;
-               break;
-            case UR_TYPE_UINT16:
-               out = &min<uint16_t>;
-               break;
-            case UR_TYPE_UINT32:
-               out = &min<uint32_t>;
-               break;
-            case UR_TYPE_UINT64:
-               out = &min<uint64_t>;
-               break;
-            case UR_TYPE_FLOAT:
-               out = &min<float>;
-               break;
-            case UR_TYPE_DOUBLE:
-               out = &min<double>;
-               break;
-            case UR_TYPE_CHAR:
-               out = &min<char>;
-               break;
-            case UR_TYPE_TIME:
-               out = &min<uint64_t>;
-               break;
-            case UR_TYPE_IP:
-               out = &min_ip;
-               break;
-            default:
-               fprintf(stderr, "Only fixed length fields can use min function, first assigned instead.\n");
-               out = &nope;
-         }
+      case UR_TYPE_INT32:
+         out = &sum<int32_t>;
          break;
-      case MAX:
-         switch (field_type) {
-            case UR_TYPE_INT8:
-               out = &max<int8_t>;
-               break;
-            case UR_TYPE_INT16:
-               out = &max<int16_t>;
-               break;
-            case UR_TYPE_INT32:
-               out = &max<int32_t>;
-               break;
-            case UR_TYPE_INT64:
-               out = &max<int64_t>;
-               break;
-            case UR_TYPE_UINT8:
-               out = &max<uint8_t>;
-               break;
-            case UR_TYPE_UINT16:
-               out = &max<uint16_t>;
-               break;
-            case UR_TYPE_UINT32:
-               out = &max<uint32_t>;
-               break;
-            case UR_TYPE_UINT64:
-               out = &max<uint64_t>;
-               break;
-            case UR_TYPE_FLOAT:
-               out = &max<float>;
-               break;
-            case UR_TYPE_DOUBLE:
-               out = &max<double>;
-               break;
-            case UR_TYPE_CHAR:
-               out = &max<char>;
-               break;
-            case UR_TYPE_TIME:
-               out = &max<uint64_t>;
-               break;
-            case UR_TYPE_IP:
-               out = &max_ip;
-               break;
-            default:
-               fprintf(stderr, "Only fixed length fields can use max function, first assigned instead.\n");
-               out = &nope;
-         }
+      case UR_TYPE_INT64:
+         out = &sum<int64_t>;
          break;
-      case FIRST:
-         // Keep nope function because first value is set by copy from input record
+      case UR_TYPE_UINT8:
+         out = &sum<uint8_t>;
+         break;
+      case UR_TYPE_UINT16:
+         out = &sum<uint16_t>;
+         break;
+      case UR_TYPE_UINT32:
+         out = &sum<uint32_t>;
+         break;
+      case UR_TYPE_UINT64:
+         out = &sum<uint64_t>;
+         break;
+      case UR_TYPE_FLOAT:
+         out = &sum<float>;
+         break;
+      case UR_TYPE_DOUBLE:
+         out = &sum<double>;
+         break;
+      default:
+         fprintf(stderr, "Only int, uint, float and double can use sum function, first assigned instead.\n");
          out = &nope;
-         break;
+      }
+      break;
 
-      case FIRST_NONEMPTY:
-         // Keep nope function because first value is set by copy from input record
-         switch (field_type) {
-            case UR_TYPE_INT8:
-               out = &first_nonempty<int8_t>;
-               break;
-            case UR_TYPE_INT16:
-               out = &first_nonempty<int16_t>;
-               break;
-            case UR_TYPE_INT32:
-               out = &first_nonempty<int32_t>;
-               break;
-            case UR_TYPE_INT64:
-               out = &first_nonempty<int64_t>;
-               break;
-            case UR_TYPE_UINT8:
-               out = &first_nonempty<uint8_t>;
-               break;
-            case UR_TYPE_UINT16:
-               out = &first_nonempty<uint16_t>;
-               break;
-            case UR_TYPE_UINT32:
-               out = &first_nonempty<uint32_t>;
-               break;
-            case UR_TYPE_UINT64:
-               out = &first_nonempty<uint64_t>;
-               break;
-            case UR_TYPE_FLOAT:
-               out = &first_nonempty<float>;
-               break;
-            case UR_TYPE_DOUBLE:
-               out = &first_nonempty<double>;
-               break;
-            case UR_TYPE_CHAR:
-               out = &first_nonempty<char>;
-               break;
-            case UR_TYPE_TIME:
-               out = &first_nonempty<uint64_t>;
-               break;
-            case UR_TYPE_IP:
-               out = &first_nonempty_ip;
-               break;
-            case UR_TYPE_STRING:
-            case UR_TYPE_BYTES:
-            case UR_TYPE_A_UINT8:
-            case UR_TYPE_A_INT8:
-            case UR_TYPE_A_UINT16:
-            case UR_TYPE_A_INT16:
-            case UR_TYPE_A_UINT32:
-            case UR_TYPE_A_INT32:
-            case UR_TYPE_A_UINT64:
-            case UR_TYPE_A_INT64:
-            case UR_TYPE_A_FLOAT:
-            case UR_TYPE_A_DOUBLE:
-            case UR_TYPE_A_IP:
-            case UR_TYPE_A_MAC:
-            case UR_TYPE_A_TIME:
-               out = &first_nonempty_var;
-               break;
-            default:
-               fprintf(stderr, "Type %s is not supported by current version of module, using first instead.\n", ur_field_type_str[field_type]);
-               out = &nope;
-         }
+   case AVG:
+      switch (field_type) {
+      case UR_TYPE_INT8:
+         out = &avg<int8_t>;
          break;
-      case LAST:
-         switch (field_type) {
-            case UR_TYPE_INT8:
-               out = &last<int8_t>;
-               break;
-            case UR_TYPE_INT16:
-               out = &last<int16_t>;
-               break;
-            case UR_TYPE_INT32:
-               out = &last<int32_t>;
-               break;
-            case UR_TYPE_INT64:
-               out = &last<int64_t>;
-               break;
-            case UR_TYPE_UINT8:
-               out = &last<uint8_t>;
-               break;
-            case UR_TYPE_UINT16:
-               out = &last<uint16_t>;
-               break;
-            case UR_TYPE_UINT32:
-               out = &last<uint32_t>;
-               break;
-            case UR_TYPE_UINT64:
-               out = &last<uint64_t>;
-               break;
-            case UR_TYPE_FLOAT:
-               out = &last<float>;
-               break;
-            case UR_TYPE_DOUBLE:
-               out = &last<double>;
-               break;
-            case UR_TYPE_CHAR:
-               out = &last<char>;
-               break;
-            case UR_TYPE_TIME:
-               out = &last<uint64_t>;
-               break;
-            case UR_TYPE_IP:
-               out = &last<ip_addr_t>;
-               break;
-            case UR_TYPE_STRING:
-               out = &last_variable;
-               break;
-            case UR_TYPE_BYTES:
-               out = &last_variable;
-               break;
-            default:
-               fprintf(stderr, "Type is not supported by current version of module, using first instead.\n");
-               out = &nope;
-         }
+      case UR_TYPE_INT16:
+         out = &avg<int16_t>;
          break;
-      case BIT_OR:
-         switch (field_type) {
-            case UR_TYPE_INT8:
-               out = &bitwise_or<int8_t>;
-               break;
-            case UR_TYPE_INT16:
-               out = &bitwise_or<int16_t>;
-               break;
-            case UR_TYPE_INT32:
-               out = &bitwise_or<int32_t>;
-               break;
-            case UR_TYPE_INT64:
-               out = &bitwise_or<int64_t>;
-               break;
-            case UR_TYPE_UINT8:
-               out = &bitwise_or<uint8_t>;
-               break;
-            case UR_TYPE_UINT16:
-               out = &bitwise_or<uint16_t>;
-               break;
-            case UR_TYPE_UINT32:
-               out = &bitwise_or<uint32_t>;
-               break;
-            case UR_TYPE_UINT64:
-               out = &bitwise_or<uint64_t>;
-               break;
-            case UR_TYPE_CHAR:
-               out = &bitwise_or<char>;
-               break;
-            default:
-               fprintf(stderr, "Only int, uint and char can use bitwise functions, first assigned instead.\n");
-               out = &nope;
-         }
+      case UR_TYPE_INT32:
+         out = &avg<int32_t>;
          break;
-      case BIT_AND:
-         switch (field_type) {
-            case UR_TYPE_INT8:
-               out = &bitwise_and<int8_t>;
-               break;
-            case UR_TYPE_INT16:
-               out = &bitwise_and<int16_t>;
-               break;
-            case UR_TYPE_INT32:
-               out = &bitwise_and<int32_t>;
-               break;
-            case UR_TYPE_INT64:
-               out = &bitwise_and<int64_t>;
-               break;
-            case UR_TYPE_UINT8:
-               out = &bitwise_and<uint8_t>;
-               break;
-            case UR_TYPE_UINT16:
-               out = &bitwise_and<uint16_t>;
-               break;
-            case UR_TYPE_UINT32:
-               out = &bitwise_and<uint32_t>;
-               break;
-            case UR_TYPE_UINT64:
-               out = &bitwise_and<uint64_t>;
-               break;
-            case UR_TYPE_CHAR:
-               out = &bitwise_and<char>;
-               break;
-            default:
-               fprintf(stderr, "Only int, uint and char can use bitwise functions, first assigned instead.\n");
-               out = &nope;
-         }
+      case UR_TYPE_INT64:
+         out = &avg<int64_t>;
          break;
+      case UR_TYPE_UINT8:
+         out = &avg<uint8_t>;
+         break;
+      case UR_TYPE_UINT16:
+         out = &avg<uint16_t>;
+         break;
+      case UR_TYPE_UINT32:
+         out = &avg<uint32_t>;
+         break;
+      case UR_TYPE_UINT64:
+         out = &avg<uint64_t>;
+         break;
+      case UR_TYPE_FLOAT:
+         out = &avg<float>;
+         break;
+      case UR_TYPE_DOUBLE:
+         out = &avg<double>;
+         break;
+      default:
+         fprintf(stderr, "Only int, uint, float and double can use avg function, first assigned instead.\n");
+         out = &nope;
+      }
+      break;
+
+   case MIN:
+      switch (field_type) {
+      case UR_TYPE_INT8:
+         out = &min<int8_t>;
+         break;
+      case UR_TYPE_INT16:
+         out = &min<int16_t>;
+         break;
+      case UR_TYPE_INT32:
+         out = &min<int32_t>;
+         break;
+      case UR_TYPE_INT64:
+         out = &min<int64_t>;
+         break;
+      case UR_TYPE_UINT8:
+         out = &min<uint8_t>;
+         break;
+      case UR_TYPE_UINT16:
+         out = &min<uint16_t>;
+         break;
+      case UR_TYPE_UINT32:
+         out = &min<uint32_t>;
+         break;
+      case UR_TYPE_UINT64:
+         out = &min<uint64_t>;
+         break;
+      case UR_TYPE_FLOAT:
+         out = &min<float>;
+         break;
+      case UR_TYPE_DOUBLE:
+         out = &min<double>;
+         break;
+      case UR_TYPE_CHAR:
+         out = &min<char>;
+         break;
+      case UR_TYPE_TIME:
+         out = &min<uint64_t>;
+         break;
+      case UR_TYPE_IP:
+         out = &min_ip;
+         break;
+      default:
+         fprintf(stderr, "Only fixed length fields can use min function, first assigned instead.\n");
+         out = &nope;
+      }
+      break;
+
+   case MAX:
+      switch (field_type) {
+      case UR_TYPE_INT8:
+         out = &max<int8_t>;
+         break;
+      case UR_TYPE_INT16:
+         out = &max<int16_t>;
+         break;
+      case UR_TYPE_INT32:
+         out = &max<int32_t>;
+         break;
+      case UR_TYPE_INT64:
+         out = &max<int64_t>;
+         break;
+      case UR_TYPE_UINT8:
+         out = &max<uint8_t>;
+         break;
+      case UR_TYPE_UINT16:
+         out = &max<uint16_t>;
+         break;
+      case UR_TYPE_UINT32:
+         out = &max<uint32_t>;
+         break;
+      case UR_TYPE_UINT64:
+         out = &max<uint64_t>;
+         break;
+      case UR_TYPE_FLOAT:
+         out = &max<float>;
+         break;
+      case UR_TYPE_DOUBLE:
+         out = &max<double>;
+         break;
+      case UR_TYPE_CHAR:
+         out = &max<char>;
+         break;
+      case UR_TYPE_TIME:
+         out = &max<uint64_t>;
+         break;
+      case UR_TYPE_IP:
+         out = &max_ip;
+         break;
+      default:
+         fprintf(stderr, "Only fixed length fields can use max function, first assigned instead.\n");
+         out = &nope;
+      }
+      break;
+
+   case FIRST:
+      // Keep nope function because first value is set by copy from input record
+      out = &nope;
+      break;
+
+   case FIRST_NONEMPTY:
+      // functions to set first non-empty / non-zero value of the field
+      switch (field_type) {
+      case UR_TYPE_INT8:
+         out = &first_nonempty<int8_t>;
+         break;
+      case UR_TYPE_INT16:
+         out = &first_nonempty<int16_t>;
+         break;
+      case UR_TYPE_INT32:
+         out = &first_nonempty<int32_t>;
+         break;
+      case UR_TYPE_INT64:
+         out = &first_nonempty<int64_t>;
+         break;
+      case UR_TYPE_UINT8:
+         out = &first_nonempty<uint8_t>;
+         break;
+      case UR_TYPE_UINT16:
+         out = &first_nonempty<uint16_t>;
+         break;
+      case UR_TYPE_UINT32:
+         out = &first_nonempty<uint32_t>;
+         break;
+      case UR_TYPE_UINT64:
+         out = &first_nonempty<uint64_t>;
+         break;
+      case UR_TYPE_FLOAT:
+         out = &first_nonempty<float>;
+         break;
+      case UR_TYPE_DOUBLE:
+         out = &first_nonempty<double>;
+         break;
+      case UR_TYPE_CHAR:
+         out = &first_nonempty<char>;
+         break;
+      case UR_TYPE_TIME:
+         out = &first_nonempty<uint64_t>;
+         break;
+      case UR_TYPE_IP:
+         out = &first_nonempty_ip;
+         break;
+      case UR_TYPE_STRING:
+      case UR_TYPE_BYTES:
+      case UR_TYPE_A_UINT8:
+      case UR_TYPE_A_INT8:
+      case UR_TYPE_A_UINT16:
+      case UR_TYPE_A_INT16:
+      case UR_TYPE_A_UINT32:
+      case UR_TYPE_A_INT32:
+      case UR_TYPE_A_UINT64:
+      case UR_TYPE_A_INT64:
+      case UR_TYPE_A_FLOAT:
+      case UR_TYPE_A_DOUBLE:
+      case UR_TYPE_A_IP:
+      case UR_TYPE_A_MAC:
+      case UR_TYPE_A_TIME:
+         out = &first_nonempty_var;
+         break;
+      default:
+         fprintf(stderr, "Type %s is not supported by current version of module, using first instead.\n", ur_field_type_str[field_type]);
+         out = &nope;
+      }
+      break;
+
+   case LAST:
+      switch (field_type) {
+      case UR_TYPE_INT8:
+         out = &last<int8_t>;
+         break;
+      case UR_TYPE_INT16:
+         out = &last<int16_t>;
+         break;
+      case UR_TYPE_INT32:
+         out = &last<int32_t>;
+         break;
+      case UR_TYPE_INT64:
+         out = &last<int64_t>;
+         break;
+      case UR_TYPE_UINT8:
+         out = &last<uint8_t>;
+         break;
+      case UR_TYPE_UINT16:
+         out = &last<uint16_t>;
+         break;
+      case UR_TYPE_UINT32:
+         out = &last<uint32_t>;
+         break;
+      case UR_TYPE_UINT64:
+         out = &last<uint64_t>;
+         break;
+      case UR_TYPE_FLOAT:
+         out = &last<float>;
+         break;
+      case UR_TYPE_DOUBLE:
+         out = &last<double>;
+         break;
+      case UR_TYPE_CHAR:
+         out = &last<char>;
+         break;
+      case UR_TYPE_TIME:
+         out = &last<uint64_t>;
+         break;
+      case UR_TYPE_IP:
+         out = &last<ip_addr_t>;
+         break;
+      case UR_TYPE_STRING:
+         out = &last_variable;
+         break;
+      case UR_TYPE_BYTES:
+         out = &last_variable;
+         break;
+      default:
+         fprintf(stderr, "Type is not supported by current version of module, using first instead.\n");
+         out = &nope;
+      }
+      break;
+
+   case BIT_OR:
+      switch (field_type) {
+      case UR_TYPE_INT8:
+         out = &bitwise_or<int8_t>;
+         break;
+      case UR_TYPE_INT16:
+         out = &bitwise_or<int16_t>;
+         break;
+      case UR_TYPE_INT32:
+         out = &bitwise_or<int32_t>;
+         break;
+      case UR_TYPE_INT64:
+         out = &bitwise_or<int64_t>;
+         break;
+      case UR_TYPE_UINT8:
+         out = &bitwise_or<uint8_t>;
+         break;
+      case UR_TYPE_UINT16:
+         out = &bitwise_or<uint16_t>;
+         break;
+      case UR_TYPE_UINT32:
+         out = &bitwise_or<uint32_t>;
+         break;
+      case UR_TYPE_UINT64:
+         out = &bitwise_or<uint64_t>;
+         break;
+      case UR_TYPE_CHAR:
+         out = &bitwise_or<char>;
+         break;
+      default:
+         fprintf(stderr, "Only int, uint and char can use bitwise functions, first assigned instead.\n");
+         out = &nope;
+      }
+      break;
+
+   case BIT_AND:
+      switch (field_type) {
+      case UR_TYPE_INT8:
+         out = &bitwise_and<int8_t>;
+         break;
+      case UR_TYPE_INT16:
+         out = &bitwise_and<int16_t>;
+         break;
+      case UR_TYPE_INT32:
+         out = &bitwise_and<int32_t>;
+         break;
+      case UR_TYPE_INT64:
+         out = &bitwise_and<int64_t>;
+         break;
+      case UR_TYPE_UINT8:
+         out = &bitwise_and<uint8_t>;
+         break;
+      case UR_TYPE_UINT16:
+         out = &bitwise_and<uint16_t>;
+         break;
+      case UR_TYPE_UINT32:
+         out = &bitwise_and<uint32_t>;
+         break;
+      case UR_TYPE_UINT64:
+         out = &bitwise_and<uint64_t>;
+         break;
+      case UR_TYPE_CHAR:
+         out = &bitwise_and<char>;
+         break;
+      default:
+         fprintf(stderr, "Only int, uint and char can use bitwise functions, first assigned instead.\n");
+         out = &nope;
+      }
+      break;
    }
    return out;
 }

--- a/aggregator/configuration.cpp
+++ b/aggregator/configuration.cpp
@@ -299,6 +299,71 @@ agg_func Config::get_function_ptr(int index, ur_field_type_t field_type)
          // Keep nope function because first value is set by copy from input record
          out = &nope;
          break;
+
+      case FIRST_NONEMPTY:
+         // Keep nope function because first value is set by copy from input record
+         switch (field_type) {
+            case UR_TYPE_INT8:
+               out = &first_nonempty<int8_t>;
+               break;
+            case UR_TYPE_INT16:
+               out = &first_nonempty<int16_t>;
+               break;
+            case UR_TYPE_INT32:
+               out = &first_nonempty<int32_t>;
+               break;
+            case UR_TYPE_INT64:
+               out = &first_nonempty<int64_t>;
+               break;
+            case UR_TYPE_UINT8:
+               out = &first_nonempty<uint8_t>;
+               break;
+            case UR_TYPE_UINT16:
+               out = &first_nonempty<uint16_t>;
+               break;
+            case UR_TYPE_UINT32:
+               out = &first_nonempty<uint32_t>;
+               break;
+            case UR_TYPE_UINT64:
+               out = &first_nonempty<uint64_t>;
+               break;
+            case UR_TYPE_FLOAT:
+               out = &first_nonempty<float>;
+               break;
+            case UR_TYPE_DOUBLE:
+               out = &first_nonempty<double>;
+               break;
+            case UR_TYPE_CHAR:
+               out = &first_nonempty<char>;
+               break;
+            case UR_TYPE_TIME:
+               out = &first_nonempty<uint64_t>;
+               break;
+            case UR_TYPE_IP:
+               out = &first_nonempty_ip;
+               break;
+            case UR_TYPE_STRING:
+            case UR_TYPE_BYTES:
+            case UR_TYPE_A_UINT8:
+            case UR_TYPE_A_INT8:
+            case UR_TYPE_A_UINT16:
+            case UR_TYPE_A_INT16:
+            case UR_TYPE_A_UINT32:
+            case UR_TYPE_A_INT32:
+            case UR_TYPE_A_UINT64:
+            case UR_TYPE_A_INT64:
+            case UR_TYPE_A_FLOAT:
+            case UR_TYPE_A_DOUBLE:
+            case UR_TYPE_A_IP:
+            case UR_TYPE_A_MAC:
+            case UR_TYPE_A_TIME:
+               out = &first_nonempty_var;
+               break;
+            default:
+               fprintf(stderr, "Type %s is not supported by current version of module, using first instead.\n", ur_field_type_str[field_type]);
+               out = &nope;
+         }
+         break;
       case LAST:
          switch (field_type) {
             case UR_TYPE_INT8:

--- a/aggregator/configuration.h
+++ b/aggregator/configuration.h
@@ -64,6 +64,8 @@
 #define BIT_OR    7
 /** Aggregation function type value defining bitwise and.*/
 #define BIT_AND   8
+/** Aggregation function type value defining first non-empty/non-zero value.*/
+#define FIRST_NONEMPTY     9
 
 /** Active timeout type value definition.*/
 #define TIMEOUT_ACTIVE           0

--- a/aggregator/key.h
+++ b/aggregator/key.h
@@ -50,7 +50,7 @@
 #define AGGREGATOR_KEYWORD_H
 
 /** Maximal supported value of fields used to have aggregation function assigned.*/
-#define MAX_KEY_FIELDS 32                 // Static maximal key members count
+#define MAX_KEY_FIELDS 64                 // Static maximal key members count
 
 /**
  * Class to represent template for key class creation.

--- a/nemea-modules.spec.in
+++ b/nemea-modules.spec.in
@@ -49,7 +49,7 @@ This package contains header file for liburfilter.
 %setup
 
 %build
-./configure -q --enable-silent-rules --disable-repobuild --prefix=%{_prefix} --libdir=%{_libdir} --bindir=%{_bindir}/nemea --sysconfdir=%{_sysconfdir} --docdir=%{_docdir}/nemea-modules --mandir=%{_mandir} --datadir=%{_datadir} --with-ndp=%{compile_ndp};
+./configure -q --enable-silent-rules --disable-repobuild --prefix=%{_prefix} --libdir=%{_libdir} --bindir=%{_bindir}/nemea --sysconfdir=%{_sysconfdir} --docdir=%{_docdir}/nemea-modules --mandir=%{_mandir} --datadir=%{_datadir} --with-ndp=%{compile_ndp} CFLAGS=-fcommon;
 make -j5
 
 %install


### PR DESCRIPTION
The new option of aggregation function allows us to choose first non-empty (or non-zero) value of the field. In practice, it checks if the size of the currently stored variable-length field is 0 or if the fixed-sized field is equal to zero.
This feature is useful, e.g., to pair flow records from several flow_meter plugins.