### PR TITLE
Refactor

### DIFF
--- a/aggregator/aggregator.cpp
+++ b/aggregator/aggregator.cpp
@@ -554,7 +554,13 @@ int main(int argc, char **argv)
 
    /* **** Create new thread for checking timeouts **** */
    pthread_t timeout_thread;
-   pthread_create(&timeout_thread, NULL, &check_timeouts, (void*)&config);
+   if (pthread_create(&timeout_thread, NULL, &check_timeouts, (void*)&config) != 0) {
+      fprintf(stderr, "Error: pthread_create\n");
+      TRAP_DEFAULT_FINALIZATION();
+      FREE_MODULE_INFO_STRUCT(MODULE_BASIC_INFO, MODULE_PARAMS);
+      return -1;
+   }
+
 
    /* **** Main processing loop **** */
 

--- a/aggregator/configuration.cpp
+++ b/aggregator/configuration.cpp
@@ -49,6 +49,9 @@ Config::Config() : used_fields(0), timeout_type(TIMEOUT_ACTIVE), variable_flag(f
    for (int i = 0; i < TIMEOUT_TYPES_COUNT; i++) {
       timeout[i] = DEFAULT_TIMEOUT;
    }
+   for (int i = 0; i < MAX_KEY_FIELDS; i++) {
+      field_names[i] = NULL;
+   }
 }
 
 

--- a/bloom_history/bloom_history.c
+++ b/bloom_history/bloom_history.c
@@ -146,6 +146,7 @@ int main(int argc, char **argv)
    signed char opt;
 
    struct bloom_history_config config;
+   bloom_history_config_init(&config);
 
    /* TRAP initialization */
    INIT_MODULE_INFO_STRUCT(MODULE_BASIC_INFO, MODULE_PARAMS)

--- a/bloom_history/bloom_history_functions.c
+++ b/bloom_history/bloom_history_functions.c
@@ -174,8 +174,6 @@ void *pthread_entry_upload(void *config_)
          free(url);
 
       }
-
-      pthread_mutex_unlock(&MUTEX_TIMER_STOP);
    }
 
    curl_free_handle(&curl);

--- a/bloom_history/libbloom/bloom.c
+++ b/bloom_history/libbloom/bloom.c
@@ -242,6 +242,7 @@ int bloom_file_write(const struct bloom * bloom, const char * filename)
 
   if (fwrite(buffer, sizeof(uint8_t), buffer_size, fp) != buffer_size) {
     fclose(fp);
+    bloom_free_serialized_buffer(&buffer);
     return -2;
   }
 

--- a/bloom_history/libbloom/bloom.c
+++ b/bloom_history/libbloom/bloom.c
@@ -205,7 +205,9 @@ int bloom_deserialize(struct bloom * bloom, const uint8_t * buffer)
   offset += sizeof(error);
 
   bloom_free(bloom);
-  bloom_init(bloom, entries, error);
+  if (bloom_init(bloom, entries, error != 0)) {
+    return -2;
+  }
 
   if (bloom->bytes != size - header_size) {
     return -2;
@@ -307,6 +309,7 @@ void bloom_free(struct bloom * bloom)
 {
   if (bloom->ready) {
     free(bloom->bf);
+    bloom->bf = NULL;
   }
   bloom->ready = 0;
 }

--- a/device_classifier/device_classifier.c
+++ b/device_classifier/device_classifier.c
@@ -388,6 +388,7 @@ void update_models_list(const char *fname)
    if (train_model_cnt > model_cnt) {
       if ((fp_model_list = fopen(fname, "a")) == NULL) {
          fprintf(stderr, "Error: Model list %s cannot be opened in write mode.\n", optarg);
+         return;
       }
       for (int i = model_cnt; i < train_model_cnt; i++) {
          fprintf(fp_model_list, "%d:%s\n", models[i].id, models[i].name);

--- a/device_classifier/device_classifier.c
+++ b/device_classifier/device_classifier.c
@@ -492,25 +492,25 @@ void compute_features(node_t *node)
 
    // Packets per source flow (ex and sd)
    ex = node->flows_src ? (node->packets_src / (double)node->flows_src) : 0;
-   var = (double)node->packets_src_2 / ((double)node->flows_src) - ex*ex;
+   var = node->flows_src ? (double)node->packets_src_2 / ((double)node->flows_src) - ex*ex : 0;
    node->features[2].value = ex;
    node->features[3].value = (node->flows_src && var > 0) ? sqrt(var): 0;
 
    // Packets per destination flow (ex and sd)
    ex = node->flows_dst ? (node->packets_dst / (double)node->flows_dst) : 0;
-   var = (double)node->packets_dst_2 / ((double)node->flows_dst) - ex*ex;
+   var = node->flows_dst ? (double)node->packets_dst_2 / ((double)node->flows_dst) - ex*ex : 0;
    node->features[4].value = ex;
    node->features[5].value = (node->flows_dst && var > 0)? sqrt(var): 0;
 
    // Seconds per source flow (ex and sd)
    ex = node->flows_src ? ((node->time_src_msec / 1000) / (double)(node->flows_src)) : 0;
-   ex_2 = ((double)(node->time_src_msec_2) / (1000*1000)) / ((double)(node->flows_src));
+   ex_2 = node->flows_src ? ((double)(node->time_src_msec_2) / (1000*1000)) / ((double)(node->flows_src)) : 0;
    node->features[6].value = ex;
    node->features[7].value = (node->flows_src && (ex_2 - ex*ex > 0)) ? sqrt(ex_2 - ex*ex): 0;
 
    // Seconds per destination flow (ex and sd)
    ex = node->flows_dst ? ((node->time_dst_msec / 1000) / (double)(node->flows_dst)) : 0;
-   ex_2 = ((double)(node->time_dst_msec_2) / (1000*1000)) / ((double)(node->flows_dst));
+   ex_2 = node->flows_dst ? ((double)(node->time_dst_msec_2) / (1000*1000)) / ((double)(node->flows_dst)) : 0;
    node->features[8].value = ex;
    node->features[9].value = (node->flows_dst && (ex_2 - ex*ex > 0)) ? sqrt(ex_2 - ex*ex): 0;
 

--- a/device_classifier/device_classifier.c
+++ b/device_classifier/device_classifier.c
@@ -394,6 +394,7 @@ void update_models_list(const char *fname)
          fprintf(fp_model_list, "%d:%s\n", models[i].id, models[i].name);
       }
    }
+   fclose(fp_model_list);
 }
 
 /**

--- a/device_classifier/device_classifier.c
+++ b/device_classifier/device_classifier.c
@@ -1116,7 +1116,7 @@ int main(int argc, char **argv)
       update_models_list(models_lst_fname);
 
       printf("\nData collected. Do you wish to launch the training script now (Y/N)?\n");
-      char c = getchar();
+      int c = getchar();
       if (c == 'Y' || c == 'y') {
          printf("Training may take a few minutes, please wait.\n");
          if ((ret = system(train_script)) != 0) {

--- a/logger/logger.c
+++ b/logger/logger.c
@@ -55,6 +55,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <getopt.h>
+#include <limits.h>
 #include <time.h>
 #include <libtrap/trap.h>
 #include <unirec/unirec.h>
@@ -288,6 +289,7 @@ int main(int argc, char **argv)
    }
 
    // Parse remaining parameters and get configuration
+   long int long_int_opt = 0;
    signed char opt;
    while ((opt = TRAP_GETOPT(argc, argv, module_getopt_string, long_options)) != -1) {
       switch (opt) {
@@ -313,11 +315,18 @@ int main(int argc, char **argv)
          break;
       case 'c':
 
-         max_num_records = strtol(optarg, NULL, 10);
-         if(max_num_records < 0)
-		 {
+         long_int_opt = strtol(optarg, NULL, 10);
+         if (max_num_records < 0) {
          	fprintf(stderr, "Error: Negative -c parameter. (max. records captured)");
-		 }
+            FREE_MODULE_INFO_STRUCT(MODULE_BASIC_INFO, MODULE_PARAMS)
+            return 1;
+         } else if (long_int_opt > UINT_MAX) {
+            fprintf(stderr, "Error: -c parameter is too large. (max. records captured)");
+            FREE_MODULE_INFO_STRUCT(MODULE_BASIC_INFO, MODULE_PARAMS)
+            return 1;
+         } else {
+            max_num_records = (unsigned int) long_int_opt;
+         }
          enabled_max_num_records = 1;
          break;
       case 'd':

--- a/merger/merger.c
+++ b/merger/merger.c
@@ -305,6 +305,11 @@ int main(int argc, char **argv)
       printf("Creating UniRec templates ...\n");
    }
 
+   if (module_info->num_ifc_in < 0) {
+      fprintf(stderr, "Error: Number of input interfaces cannot be negative.\n");
+      ret = -1;
+      goto exit;
+   }
    in_template = (ur_template_t **) calloc(module_info->num_ifc_in, sizeof(ur_template_t *));
    if (in_template == NULL) {
       fprintf(stderr, "Error: allocation of templates failed.\n");

--- a/prefix_tags/prefix_tags_config.c
+++ b/prefix_tags/prefix_tags_config.c
@@ -68,6 +68,9 @@ int parse_config(const char *config_file, ipps_context_t **config)
       fprintf(stderr, "ERROR allocating memory for network list\n");
       free(networks);
       return -1;
+   } else {
+      netlist->net_count = 0;
+      netlist->networks = NULL;
    }
 
    // Parse JSON

--- a/prefix_tags/prefix_tags_functions.c
+++ b/prefix_tags/prefix_tags_functions.c
@@ -39,7 +39,7 @@ int update_output_format(ur_template_t *template_in, const void *data_in, ur_tem
       fprintf(stderr, "Error: Recieved input template with variable sized fields - this is currently not supported.\n");
       return -1;
    }
-   if (data_out != NULL) {
+   if (*data_out != NULL) {
       ur_free_record(*data_out);
    }
    *data_out = ur_create_record(*template_out, 0); // Dynamic fields are currently not supported

--- a/scalar-aggregator/aggregator.c
+++ b/scalar-aggregator/aggregator.c
@@ -522,7 +522,7 @@ rule_t *rule_create(const char *specifier, int step, int size, int inactive_time
             }
          } else if (filter == NULL) { // or filter
             filter = (char *) calloc(i - token_start + 1, sizeof(char));
-            if (filter) {
+            if (!filter) {
                fprintf(stderr, "Error: Calloc failed during the creation of aggregation rule.\n");
                goto error_cleanup;
             }


### PR DESCRIPTION
## Report

### Division or modulo by float zero
- please check fixes in function compute_features (file device_classifier)

### Double unlock
-  please check deleted mutex_unlock in bloom_history_functions.c

### False positive
- I marked the problem with *"Explicit null dereferenced"* in the files endiverter.c and prefix_tags.c as false positive.
- Consider this pseudo-code:
```C
while(!stop) {
   trap_recv(...);
   TRAP_DEFAULT_RECV_ERROR_HANDLING(ret, continue, module_status = 1; break);
   if (ret == TRAP_E_FORMAT_CHANGED) { initialize_ur_template_t(...); }
   using_ur_template_t(...); 
}
```
- Basically, I want to confirm my assumption that the TRAP_E_FORMAT_CHANGED **always occurs before** TRAP_E_OK when using the *trap_recv* function in a loop. If this were not the case, I would have to add additional refactor commits, as there would be a risk of using an uninitialized *ur_template_t* variable.

### Other issues
- argument cannot be negative
- dereference agter null check
- resource leak
- truncated stdio return value
- unchecked return value
- uninitialized pointer read/field
- unsigned compared against 0
- use after free