### PR TITLE
json_dump: added verbose print about end-of-stream msg

### DIFF
--- a/json_dump/json_dump.py
+++ b/json_dump/json_dump.py
@@ -63,6 +63,8 @@ while not stop:
 
     # Check for "end-of-stream" record
     if len(data) <= 1:
+        if options.verbose:
+            print('Received "end-of-stream" message, going to quit.')
         break
 
     try:


### PR DESCRIPTION
A message is printed to stdout when the "end-of-stream" message is received (only when verbose mode is enabled). I just used it to debug another module sending EOS non-intentionally - it can be useful in other cases as well.