### PR TITLE
unirecfilter: Print warning when using -O with -f

### DIFF
--- a/unirecfilter/unirecfilter.c
+++ b/unirecfilter/unirecfilter.c
@@ -495,6 +495,10 @@ int main(int argc, char **argv)
       printf("Verbosity level: %i\n", verbose);
    }
 
+   if (from == 1 && output_specifier_str != NULL) {
+      fprintf(stderr, "Warning: The -O parameter is ignored when output specification is read from a file.\n");
+   }
+
    // Count number of output interfaces
    n_outputs = strlen(ifc_spec.types) - 1;
    module_info->num_ifc_out = n_outputs;


### PR DESCRIPTION
When filters are read from file (using -f parameter), the file also contains specification of the set of fields on each output. The -O parameter is overridden/ignored in such case.

This change adds a warning to notify user that the passed -O parameter has no effect.