### PR TITLE
unirec2json: bugfix failure if -M is missing

### DIFF
--- a/unirec2json/unirec2json.py
+++ b/unirec2json/unirec2json.py
@@ -79,7 +79,9 @@ while not stop:
             trap.sendFlush(0)
         break
     rec.setData(data)
-    d = apply_mappings(rec.getDict(), mapping)
+    d = rec.getDict()
+    if mapping:
+        d = apply_mappings(d, mapping)
     j = json.dumps(d, default=default)
     if options.verbose:
         print(j)


### PR DESCRIPTION
apply_mapping() is called only when a -M parameter was provided.