### PR TITLE
anonymizer: option to skip SRC_IP (-S)/DST_IP (-D)

### DIFF
--- a/anonymizer/README
+++ b/anonymizer/README
@@ -28,5 +28,7 @@ Anonymization key: 32 characters long string or 32B sized hex string starting wi
 
 Parameters: -k KEY     Specify anonymization key.
             -f FILE    Specify file containg anonymization key.
+            -S         Disable anonymization of SRC_IP.
+            -D         Disable anonymization of DST_IP.
             -M         Use MurmurHash3 instead of Rijndael cipher.
             -d         Switch to de-anonymization mode, i.e. do reverse transofmration of the addresses.


### PR DESCRIPTION
Two optional parameters were added to skip anonymization of SRC_IP (option -S) or DST_IP (option -D).

Example to leave SRC_IP without any modification:
/usr/bin/nemea/anonymizer -i u:input,u:output -S

Example to leave both SRC_IP and DST_IP without any modification: /usr/bin/nemea/anonymizer -i u:input,u:output -S -D